### PR TITLE
chore(stlc): migrate SDK generation to local stlc builds

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
 configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",

--- a/src/TryCourier/Models/Send/SendMessageParams.cs
+++ b/src/TryCourier/Models/Send/SendMessageParams.cs
@@ -14,7 +14,8 @@ namespace TryCourier.Models.Send;
 
 /// <summary>
 /// Sends a message to one or more recipients and returns a requestId. Courier routes
-/// it to email, SMS, push, chat, or in-app based on your rules.
+/// it to email, SMS, push, chat, or in-app based on your rules. Use the returned
+/// requestId to look up delivery status via the Messages API.
 ///
 /// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
 /// breaking changes in non-major versions. We may add new methods in the future that

--- a/src/TryCourier/Services/ISendService.cs
+++ b/src/TryCourier/Services/ISendService.cs
@@ -31,7 +31,8 @@ public interface ISendService
 
     /// <summary>
     /// Sends a message to one or more recipients and returns a requestId. Courier
-    /// routes it to email, SMS, push, chat, or in-app based on your rules.
+    /// routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+    /// returned requestId to look up delivery status via the Messages API.
     /// </summary>
     Task<SendMessageResponse> Message(
         SendMessageParams parameters,

--- a/src/TryCourier/TryCourier.csproj
+++ b/src/TryCourier/TryCourier.csproj
@@ -3,7 +3,7 @@
     <!-- Metadata -->
     <AssemblyTitle>Courier C#</AssemblyTitle>
     <AssemblyName>TryCourier</AssemblyName>
-    <VersionPrefix>5.22.0</VersionPrefix>
+    <VersionPrefix>5.16.2</VersionPrefix>
     <Description>The official .NET library for the Courier API.</Description>
     <OutputType>Library</OutputType>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/TryCourier/TryCourier.csproj
+++ b/src/TryCourier/TryCourier.csproj
@@ -3,18 +3,18 @@
     <!-- Metadata -->
     <AssemblyTitle>Courier C#</AssemblyTitle>
     <AssemblyName>TryCourier</AssemblyName>
-    <VersionPrefix>5.16.2</VersionPrefix>
+    <VersionPrefix>5.22.0</VersionPrefix>
     <Description>The official .NET library for the Courier API.</Description>
     <OutputType>Library</OutputType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="TryCourier.Tests"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.9"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <InternalsVisibleTo Include="TryCourier.Tests" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Generated by [stlc](https://github.com/trycourier/api-spec) from https://github.com/trycourier/api-spec/commit/3c2d1f00a85a5e18cfe03f18b4ac446ffd8b2812.

## Merge with a **merge commit** — do not squash or rebase

The custom-code tracking files in `trycourier/api-spec` reference this branch's sealed commit **by SHA**. Squashing or rebasing rewrites it, so the sealed commit is no longer reachable from `main` and the next `stlc build` fails with `origin/main has diverged from the last sealed integrated commit`.

## What happens next

Merging lands the regenerated SDK on `main`. If the title above is a releasable Conventional Commit (`feat`/`fix`/`perf`), release-please then opens a release PR here; `chore`/`docs` land in the changelog without cutting a release.
