### PR TITLE
chore(api): regenerate SDK

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
-configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0
+configured_endpoints: 150

--- a/src/TryCourier.Tests/Models/Bulk/BulkAddUsersParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkAddUsersParamsTest.cs
@@ -1,0 +1,408 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Models;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkAddUsersParamsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var parameters = new BulkAddUsersParams
+        {
+            JobID = "job_id",
+            Users =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                },
+            ],
+        };
+
+        string expectedJobID = "job_id";
+        List<InboundBulkMessageUser> expectedUsers =
+        [
+            new()
+            {
+                Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                Preferences = new()
+                {
+                    Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                    Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                },
+                Profile = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Recipient = "recipient",
+                To = new()
+                {
+                    AccountID = "account_id",
+                    Context = new() { TenantID = "tenant_id" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Email = "email",
+                    ListID = "list_id",
+                    Locale = "locale",
+                    PhoneNumber = "phone_number",
+                    Preferences = new()
+                    {
+                        Notifications = new Dictionary<string, Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Source.Subscription,
+                                }
+                            },
+                        },
+                        Categories = new Dictionary<string, Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Source.Subscription,
+                                }
+                            },
+                        },
+                        TemplateID = "templateId",
+                    },
+                    TenantID = "tenant_id",
+                    UserID = "user_id",
+                },
+            },
+        ];
+
+        Assert.Equal(expectedJobID, parameters.JobID);
+        Assert.Equal(expectedUsers.Count, parameters.Users.Count);
+        for (int i = 0; i < expectedUsers.Count; i++)
+        {
+            Assert.Equal(expectedUsers[i], parameters.Users[i]);
+        }
+    }
+
+    [Fact]
+    public void Url_Works()
+    {
+        BulkAddUsersParams parameters = new()
+        {
+            JobID = "job_id",
+            Users =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                },
+            ],
+        };
+
+        var url = parameters.Url(new() { ApiKey = "My API Key" });
+
+        Assert.True(TestBase.UrisEqual(new Uri("https://api.courier.com/bulk/job_id"), url));
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var parameters = new BulkAddUsersParams
+        {
+            JobID = "job_id",
+            Users =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                },
+            ],
+        };
+
+        BulkAddUsersParams copied = new(parameters);
+
+        Assert.Equal(parameters, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Models;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkCreateJobParamsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var parameters = new BulkCreateJobParams
+        {
+            Message = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+        };
+
+        InboundBulkMessage expectedMessage = new()
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        Assert.Equal(expectedMessage, parameters.Message);
+    }
+
+    [Fact]
+    public void Url_Works()
+    {
+        BulkCreateJobParams parameters = new()
+        {
+            Message = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+        };
+
+        var url = parameters.Url(new() { ApiKey = "My API Key" });
+
+        Assert.True(TestBase.UrisEqual(new Uri("https://api.courier.com/bulk"), url));
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var parameters = new BulkCreateJobParams
+        {
+            Message = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+        };
+
+        BulkCreateJobParams copied = new(parameters);
+
+        Assert.Equal(parameters, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkCreateJobResponseTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkCreateJobResponseTest.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkCreateJobResponseTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new BulkCreateJobResponse { JobID = "jobId" };
+
+        string expectedJobID = "jobId";
+
+        Assert.Equal(expectedJobID, model.JobID);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new BulkCreateJobResponse { JobID = "jobId" };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkCreateJobResponse>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new BulkCreateJobResponse { JobID = "jobId" };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkCreateJobResponse>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        string expectedJobID = "jobId";
+
+        Assert.Equal(expectedJobID, deserialized.JobID);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new BulkCreateJobResponse { JobID = "jobId" };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new BulkCreateJobResponse { JobID = "jobId" };
+
+        BulkCreateJobResponse copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkListUsersParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkListUsersParamsTest.cs
@@ -1,0 +1,67 @@
+using System;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkListUsersParamsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var parameters = new BulkListUsersParams { JobID = "job_id", Cursor = "cursor" };
+
+        string expectedJobID = "job_id";
+        string expectedCursor = "cursor";
+
+        Assert.Equal(expectedJobID, parameters.JobID);
+        Assert.Equal(expectedCursor, parameters.Cursor);
+    }
+
+    [Fact]
+    public void OptionalNullableParamsUnsetAreNotSet_Works()
+    {
+        var parameters = new BulkListUsersParams { JobID = "job_id" };
+
+        Assert.Null(parameters.Cursor);
+        Assert.False(parameters.RawQueryData.ContainsKey("cursor"));
+    }
+
+    [Fact]
+    public void OptionalNullableParamsSetToNullAreSetToNull_Works()
+    {
+        var parameters = new BulkListUsersParams
+        {
+            JobID = "job_id",
+
+            Cursor = null,
+        };
+
+        Assert.Null(parameters.Cursor);
+        Assert.True(parameters.RawQueryData.ContainsKey("cursor"));
+    }
+
+    [Fact]
+    public void Url_Works()
+    {
+        BulkListUsersParams parameters = new() { JobID = "job_id", Cursor = "cursor" };
+
+        var url = parameters.Url(new() { ApiKey = "My API Key" });
+
+        Assert.True(
+            TestBase.UrisEqual(
+                new Uri("https://api.courier.com/bulk/job_id/users?cursor=cursor"),
+                url
+            )
+        );
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var parameters = new BulkListUsersParams { JobID = "job_id", Cursor = "cursor" };
+
+        BulkListUsersParams copied = new(parameters);
+
+        Assert.Equal(parameters, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkListUsersResponseTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkListUsersResponseTest.cs
@@ -1,0 +1,2114 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using TryCourier.Models.Bulk;
+using Models = TryCourier.Models;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkListUsersResponseTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new BulkListUsersResponse
+        {
+            Items =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<
+                            string,
+                            Models::NotificationPreferenceDetails
+                        >()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                    Status = Status.Pending,
+                    MessageID = "messageId",
+                },
+            ],
+            Paging = new() { More = true, Cursor = "cursor" },
+        };
+
+        List<Item> expectedItems =
+        [
+            new()
+            {
+                Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                Preferences = new()
+                {
+                    Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                    Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                },
+                Profile = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Recipient = "recipient",
+                To = new()
+                {
+                    AccountID = "account_id",
+                    Context = new() { TenantID = "tenant_id" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Email = "email",
+                    ListID = "list_id",
+                    Locale = "locale",
+                    PhoneNumber = "phone_number",
+                    Preferences = new()
+                    {
+                        Notifications = new Dictionary<string, Models::Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Models::Source.Subscription,
+                                }
+                            },
+                        },
+                        Categories = new Dictionary<string, Models::Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Models::Source.Subscription,
+                                }
+                            },
+                        },
+                        TemplateID = "templateId",
+                    },
+                    TenantID = "tenant_id",
+                    UserID = "user_id",
+                },
+                Status = Status.Pending,
+                MessageID = "messageId",
+            },
+        ];
+        Models::Paging expectedPaging = new() { More = true, Cursor = "cursor" };
+
+        Assert.Equal(expectedItems.Count, model.Items.Count);
+        for (int i = 0; i < expectedItems.Count; i++)
+        {
+            Assert.Equal(expectedItems[i], model.Items[i]);
+        }
+        Assert.Equal(expectedPaging, model.Paging);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new BulkListUsersResponse
+        {
+            Items =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<
+                            string,
+                            Models::NotificationPreferenceDetails
+                        >()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                    Status = Status.Pending,
+                    MessageID = "messageId",
+                },
+            ],
+            Paging = new() { More = true, Cursor = "cursor" },
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkListUsersResponse>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new BulkListUsersResponse
+        {
+            Items =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<
+                            string,
+                            Models::NotificationPreferenceDetails
+                        >()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                    Status = Status.Pending,
+                    MessageID = "messageId",
+                },
+            ],
+            Paging = new() { More = true, Cursor = "cursor" },
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkListUsersResponse>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        List<Item> expectedItems =
+        [
+            new()
+            {
+                Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                Preferences = new()
+                {
+                    Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                    Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                },
+                Profile = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Recipient = "recipient",
+                To = new()
+                {
+                    AccountID = "account_id",
+                    Context = new() { TenantID = "tenant_id" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Email = "email",
+                    ListID = "list_id",
+                    Locale = "locale",
+                    PhoneNumber = "phone_number",
+                    Preferences = new()
+                    {
+                        Notifications = new Dictionary<string, Models::Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Models::Source.Subscription,
+                                }
+                            },
+                        },
+                        Categories = new Dictionary<string, Models::Preference>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                    Source = Models::Source.Subscription,
+                                }
+                            },
+                        },
+                        TemplateID = "templateId",
+                    },
+                    TenantID = "tenant_id",
+                    UserID = "user_id",
+                },
+                Status = Status.Pending,
+                MessageID = "messageId",
+            },
+        ];
+        Models::Paging expectedPaging = new() { More = true, Cursor = "cursor" };
+
+        Assert.Equal(expectedItems.Count, deserialized.Items.Count);
+        for (int i = 0; i < expectedItems.Count; i++)
+        {
+            Assert.Equal(expectedItems[i], deserialized.Items[i]);
+        }
+        Assert.Equal(expectedPaging, deserialized.Paging);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new BulkListUsersResponse
+        {
+            Items =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<
+                            string,
+                            Models::NotificationPreferenceDetails
+                        >()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                    Status = Status.Pending,
+                    MessageID = "messageId",
+                },
+            ],
+            Paging = new() { More = true, Cursor = "cursor" },
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new BulkListUsersResponse
+        {
+            Items =
+            [
+                new()
+                {
+                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<
+                            string,
+                            Models::NotificationPreferenceDetails
+                        >()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = Models::PreferenceStatus.OptedIn,
+                                    ChannelPreferences =
+                                    [
+                                        new(Models::ChannelClassification.DirectMessage),
+                                    ],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Recipient = "recipient",
+                    To = new()
+                    {
+                        AccountID = "account_id",
+                        Context = new() { TenantID = "tenant_id" },
+                        Data = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Email = "email",
+                        ListID = "list_id",
+                        Locale = "locale",
+                        PhoneNumber = "phone_number",
+                        Preferences = new()
+                        {
+                            Notifications = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            Categories = new Dictionary<string, Models::Preference>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = Models::PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(Models::ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                        Source = Models::Source.Subscription,
+                                    }
+                                },
+                            },
+                            TemplateID = "templateId",
+                        },
+                        TenantID = "tenant_id",
+                        UserID = "user_id",
+                    },
+                    Status = Status.Pending,
+                    MessageID = "messageId",
+                },
+            ],
+            Paging = new() { More = true, Cursor = "cursor" },
+        };
+
+        BulkListUsersResponse copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class ItemTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        JsonElement expectedData = JsonSerializer.Deserialize<JsonElement>("{}");
+        Models::RecipientPreferences expectedPreferences = new()
+        {
+            Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = Models::PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+            Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = Models::PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+        };
+        Dictionary<string, JsonElement> expectedProfile = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedRecipient = "recipient";
+        Models::UserRecipient expectedTo = new()
+        {
+            AccountID = "account_id",
+            Context = new() { TenantID = "tenant_id" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Email = "email",
+            ListID = "list_id",
+            Locale = "locale",
+            PhoneNumber = "phone_number",
+            Preferences = new()
+            {
+                Notifications = new Dictionary<string, Models::Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Models::Source.Subscription,
+                        }
+                    },
+                },
+                Categories = new Dictionary<string, Models::Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Models::Source.Subscription,
+                        }
+                    },
+                },
+                TemplateID = "templateId",
+            },
+            TenantID = "tenant_id",
+            UserID = "user_id",
+        };
+        ApiEnum<string, Status> expectedStatus = Status.Pending;
+        string expectedMessageID = "messageId";
+
+        Assert.NotNull(model.Data);
+        Assert.True(JsonElement.DeepEquals(expectedData, model.Data.Value));
+        Assert.Equal(expectedPreferences, model.Preferences);
+        Assert.NotNull(model.Profile);
+        Assert.Equal(expectedProfile.Count, model.Profile.Count);
+        foreach (var item in expectedProfile)
+        {
+            Assert.True(model.Profile.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, model.Profile[item.Key]));
+        }
+        Assert.Equal(expectedRecipient, model.Recipient);
+        Assert.Equal(expectedTo, model.To);
+        Assert.Equal(expectedStatus, model.Status);
+        Assert.Equal(expectedMessageID, model.MessageID);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Item>(json, ModelBase.SerializerOptions);
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Item>(element, ModelBase.SerializerOptions);
+        Assert.NotNull(deserialized);
+
+        JsonElement expectedData = JsonSerializer.Deserialize<JsonElement>("{}");
+        Models::RecipientPreferences expectedPreferences = new()
+        {
+            Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = Models::PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+            Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = Models::PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+        };
+        Dictionary<string, JsonElement> expectedProfile = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedRecipient = "recipient";
+        Models::UserRecipient expectedTo = new()
+        {
+            AccountID = "account_id",
+            Context = new() { TenantID = "tenant_id" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Email = "email",
+            ListID = "list_id",
+            Locale = "locale",
+            PhoneNumber = "phone_number",
+            Preferences = new()
+            {
+                Notifications = new Dictionary<string, Models::Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Models::Source.Subscription,
+                        }
+                    },
+                },
+                Categories = new Dictionary<string, Models::Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Models::Source.Subscription,
+                        }
+                    },
+                },
+                TemplateID = "templateId",
+            },
+            TenantID = "tenant_id",
+            UserID = "user_id",
+        };
+        ApiEnum<string, Status> expectedStatus = Status.Pending;
+        string expectedMessageID = "messageId";
+
+        Assert.NotNull(deserialized.Data);
+        Assert.True(JsonElement.DeepEquals(expectedData, deserialized.Data.Value));
+        Assert.Equal(expectedPreferences, deserialized.Preferences);
+        Assert.NotNull(deserialized.Profile);
+        Assert.Equal(expectedProfile.Count, deserialized.Profile.Count);
+        foreach (var item in expectedProfile)
+        {
+            Assert.True(deserialized.Profile.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, deserialized.Profile[item.Key]));
+        }
+        Assert.Equal(expectedRecipient, deserialized.Recipient);
+        Assert.Equal(expectedTo, deserialized.To);
+        Assert.Equal(expectedStatus, deserialized.Status);
+        Assert.Equal(expectedMessageID, deserialized.MessageID);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new Item
+        {
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        Assert.Null(model.Data);
+        Assert.False(model.RawData.ContainsKey("data"));
+        Assert.Null(model.Preferences);
+        Assert.False(model.RawData.ContainsKey("preferences"));
+        Assert.Null(model.To);
+        Assert.False(model.RawData.ContainsKey("to"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new Item
+        {
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullAreNotSet_Works()
+    {
+        var model = new Item
+        {
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            Status = Status.Pending,
+            MessageID = "messageId",
+
+            // Null should be interpreted as omitted for these properties
+            Data = null,
+            Preferences = null,
+            To = null,
+        };
+
+        Assert.Null(model.Data);
+        Assert.False(model.RawData.ContainsKey("data"));
+        Assert.Null(model.Preferences);
+        Assert.False(model.RawData.ContainsKey("preferences"));
+        Assert.Null(model.To);
+        Assert.False(model.RawData.ContainsKey("to"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new Item
+        {
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            Status = Status.Pending,
+            MessageID = "messageId",
+
+            // Null should be interpreted as omitted for these properties
+            Data = null,
+            Preferences = null,
+            To = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+        };
+
+        Assert.Null(model.Profile);
+        Assert.False(model.RawData.ContainsKey("profile"));
+        Assert.Null(model.Recipient);
+        Assert.False(model.RawData.ContainsKey("recipient"));
+        Assert.Null(model.MessageID);
+        Assert.False(model.RawData.ContainsKey("messageId"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullAreSetToNull_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+
+            Profile = null,
+            Recipient = null,
+            MessageID = null,
+        };
+
+        Assert.Null(model.Profile);
+        Assert.True(model.RawData.ContainsKey("profile"));
+        Assert.Null(model.Recipient);
+        Assert.True(model.RawData.ContainsKey("recipient"));
+        Assert.Null(model.MessageID);
+        Assert.True(model.RawData.ContainsKey("messageId"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+
+            Profile = null,
+            Recipient = null,
+            MessageID = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new Item
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, Models::NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = Models::PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(Models::ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Models::Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = Models::PreferenceStatus.OptedIn,
+                                ChannelPreferences =
+                                [
+                                    new(Models::ChannelClassification.DirectMessage),
+                                ],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Models::Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+            Status = Status.Pending,
+            MessageID = "messageId",
+        };
+
+        Item copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class IntersectionMember1Test : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending, MessageID = "messageId" };
+
+        ApiEnum<string, Status> expectedStatus = Status.Pending;
+        string expectedMessageID = "messageId";
+
+        Assert.Equal(expectedStatus, model.Status);
+        Assert.Equal(expectedMessageID, model.MessageID);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending, MessageID = "messageId" };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<IntersectionMember1>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending, MessageID = "messageId" };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<IntersectionMember1>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        ApiEnum<string, Status> expectedStatus = Status.Pending;
+        string expectedMessageID = "messageId";
+
+        Assert.Equal(expectedStatus, deserialized.Status);
+        Assert.Equal(expectedMessageID, deserialized.MessageID);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending, MessageID = "messageId" };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending };
+
+        Assert.Null(model.MessageID);
+        Assert.False(model.RawData.ContainsKey("messageId"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullAreSetToNull_Works()
+    {
+        var model = new IntersectionMember1
+        {
+            Status = Status.Pending,
+
+            MessageID = null,
+        };
+
+        Assert.Null(model.MessageID);
+        Assert.True(model.RawData.ContainsKey("messageId"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new IntersectionMember1
+        {
+            Status = Status.Pending,
+
+            MessageID = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new IntersectionMember1 { Status = Status.Pending, MessageID = "messageId" };
+
+        IntersectionMember1 copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class StatusTest : TestBase
+{
+    [Theory]
+    [InlineData(Status.Pending)]
+    [InlineData(Status.Enqueued)]
+    [InlineData(Status.Error)]
+    public void Validation_Works(Status rawValue)
+    {
+        // force implicit conversion because Theory can't do that for us
+        ApiEnum<string, Status> value = rawValue;
+        value.Validate();
+    }
+
+    [Fact]
+    public void InvalidEnumValidationThrows_Works()
+    {
+        var value = JsonSerializer.Deserialize<ApiEnum<string, Status>>(
+            JsonSerializer.SerializeToElement("invalid value"),
+            ModelBase.SerializerOptions
+        );
+
+        Assert.NotNull(value);
+        Assert.Throws<CourierInvalidDataException>(() => value.Validate());
+    }
+
+    [Theory]
+    [InlineData(Status.Pending)]
+    [InlineData(Status.Enqueued)]
+    [InlineData(Status.Error)]
+    public void SerializationRoundtrip_Works(Status rawValue)
+    {
+        // force implicit conversion because Theory can't do that for us
+        ApiEnum<string, Status> value = rawValue;
+
+        string json = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<ApiEnum<string, Status>>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+
+    [Fact]
+    public void InvalidEnumSerializationRoundtrip_Works()
+    {
+        var value = JsonSerializer.Deserialize<ApiEnum<string, Status>>(
+            JsonSerializer.SerializeToElement("invalid value"),
+            ModelBase.SerializerOptions
+        );
+        string json = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<ApiEnum<string, Status>>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobParamsTest.cs
@@ -1,0 +1,37 @@
+using System;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkRetrieveJobParamsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var parameters = new BulkRetrieveJobParams { JobID = "job_id" };
+
+        string expectedJobID = "job_id";
+
+        Assert.Equal(expectedJobID, parameters.JobID);
+    }
+
+    [Fact]
+    public void Url_Works()
+    {
+        BulkRetrieveJobParams parameters = new() { JobID = "job_id" };
+
+        var url = parameters.Url(new() { ApiKey = "My API Key" });
+
+        Assert.True(TestBase.UrisEqual(new Uri("https://api.courier.com/bulk/job_id"), url));
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var parameters = new BulkRetrieveJobParams { JobID = "job_id" };
+
+        BulkRetrieveJobParams copied = new(parameters);
+
+        Assert.Equal(parameters, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobResponseTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobResponseTest.cs
@@ -1,0 +1,639 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using TryCourier.Models;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkRetrieveJobResponseTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new BulkRetrieveJobResponse
+        {
+            Job = new()
+            {
+                Definition = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+                Enqueued = 0,
+                Failures = 0,
+                Received = 0,
+                Status = JobStatus.Created,
+            },
+        };
+
+        Job expectedJob = new()
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        Assert.Equal(expectedJob, model.Job);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new BulkRetrieveJobResponse
+        {
+            Job = new()
+            {
+                Definition = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+                Enqueued = 0,
+                Failures = 0,
+                Received = 0,
+                Status = JobStatus.Created,
+            },
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkRetrieveJobResponse>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new BulkRetrieveJobResponse
+        {
+            Job = new()
+            {
+                Definition = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+                Enqueued = 0,
+                Failures = 0,
+                Received = 0,
+                Status = JobStatus.Created,
+            },
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<BulkRetrieveJobResponse>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        Job expectedJob = new()
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        Assert.Equal(expectedJob, deserialized.Job);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new BulkRetrieveJobResponse
+        {
+            Job = new()
+            {
+                Definition = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+                Enqueued = 0,
+                Failures = 0,
+                Received = 0,
+                Status = JobStatus.Created,
+            },
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new BulkRetrieveJobResponse
+        {
+            Job = new()
+            {
+                Definition = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+                Enqueued = 0,
+                Failures = 0,
+                Received = 0,
+                Status = JobStatus.Created,
+            },
+        };
+
+        BulkRetrieveJobResponse copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class JobTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new Job
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        InboundBulkMessage expectedDefinition = new()
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+        long expectedEnqueued = 0;
+        long expectedFailures = 0;
+        long expectedReceived = 0;
+        ApiEnum<string, JobStatus> expectedStatus = JobStatus.Created;
+
+        Assert.Equal(expectedDefinition, model.Definition);
+        Assert.Equal(expectedEnqueued, model.Enqueued);
+        Assert.Equal(expectedFailures, model.Failures);
+        Assert.Equal(expectedReceived, model.Received);
+        Assert.Equal(expectedStatus, model.Status);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new Job
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Job>(json, ModelBase.SerializerOptions);
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new Job
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Job>(element, ModelBase.SerializerOptions);
+        Assert.NotNull(deserialized);
+
+        InboundBulkMessage expectedDefinition = new()
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+        long expectedEnqueued = 0;
+        long expectedFailures = 0;
+        long expectedReceived = 0;
+        ApiEnum<string, JobStatus> expectedStatus = JobStatus.Created;
+
+        Assert.Equal(expectedDefinition, deserialized.Definition);
+        Assert.Equal(expectedEnqueued, deserialized.Enqueued);
+        Assert.Equal(expectedFailures, deserialized.Failures);
+        Assert.Equal(expectedReceived, deserialized.Received);
+        Assert.Equal(expectedStatus, deserialized.Status);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new Job
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new Job
+        {
+            Definition = new()
+            {
+                Event = "event",
+                Brand = "brand",
+                Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                {
+                    {
+                        "foo",
+                        new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        }
+                    },
+                },
+                Override = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Template = "template",
+            },
+            Enqueued = 0,
+            Failures = 0,
+            Received = 0,
+            Status = JobStatus.Created,
+        };
+
+        Job copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class JobStatusTest : TestBase
+{
+    [Theory]
+    [InlineData(JobStatus.Created)]
+    [InlineData(JobStatus.Processing)]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Error)]
+    public void Validation_Works(JobStatus rawValue)
+    {
+        // force implicit conversion because Theory can't do that for us
+        ApiEnum<string, JobStatus> value = rawValue;
+        value.Validate();
+    }
+
+    [Fact]
+    public void InvalidEnumValidationThrows_Works()
+    {
+        var value = JsonSerializer.Deserialize<ApiEnum<string, JobStatus>>(
+            JsonSerializer.SerializeToElement("invalid value"),
+            ModelBase.SerializerOptions
+        );
+
+        Assert.NotNull(value);
+        Assert.Throws<CourierInvalidDataException>(() => value.Validate());
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Created)]
+    [InlineData(JobStatus.Processing)]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Error)]
+    public void SerializationRoundtrip_Works(JobStatus rawValue)
+    {
+        // force implicit conversion because Theory can't do that for us
+        ApiEnum<string, JobStatus> value = rawValue;
+
+        string json = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<ApiEnum<string, JobStatus>>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+
+    [Fact]
+    public void InvalidEnumSerializationRoundtrip_Works()
+    {
+        var value = JsonSerializer.Deserialize<ApiEnum<string, JobStatus>>(
+            JsonSerializer.SerializeToElement("invalid value"),
+            ModelBase.SerializerOptions
+        );
+        string json = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<ApiEnum<string, JobStatus>>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/BulkRunJobParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkRunJobParamsTest.cs
@@ -1,0 +1,37 @@
+using System;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class BulkRunJobParamsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var parameters = new BulkRunJobParams { JobID = "job_id" };
+
+        string expectedJobID = "job_id";
+
+        Assert.Equal(expectedJobID, parameters.JobID);
+    }
+
+    [Fact]
+    public void Url_Works()
+    {
+        BulkRunJobParams parameters = new() { JobID = "job_id" };
+
+        var url = parameters.Url(new() { ApiKey = "My API Key" });
+
+        Assert.True(TestBase.UrisEqual(new Uri("https://api.courier.com/bulk/job_id/run"), url));
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var parameters = new BulkRunJobParams { JobID = "job_id" };
+
+        BulkRunJobParams copied = new(parameters);
+
+        Assert.Equal(parameters, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/InboundBulkMessageTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/InboundBulkMessageTest.cs
@@ -1,0 +1,444 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Models;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class InboundBulkMessageTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        string expectedEvent = "event";
+        string expectedBrand = "brand";
+        Content expectedContent = new ElementalContentSugar() { Body = "body", Title = "title" };
+        Dictionary<string, JsonElement> expectedData = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        Dictionary<string, Dictionary<string, JsonElement>> expectedLocale = new()
+        {
+            {
+                "foo",
+                new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                }
+            },
+        };
+        Dictionary<string, JsonElement> expectedOverride = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedTemplate = "template";
+
+        Assert.Equal(expectedEvent, model.Event);
+        Assert.Equal(expectedBrand, model.Brand);
+        Assert.Equal(expectedContent, model.Content);
+        Assert.NotNull(model.Data);
+        Assert.Equal(expectedData.Count, model.Data.Count);
+        foreach (var item in expectedData)
+        {
+            Assert.True(model.Data.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, model.Data[item.Key]));
+        }
+        Assert.NotNull(model.Locale);
+        Assert.Equal(expectedLocale.Count, model.Locale.Count);
+        foreach (var item in expectedLocale)
+        {
+            Assert.True(model.Locale.TryGetValue(item.Key, out var value));
+
+            Assert.Equal(value.Count, model.Locale[item.Key].Count);
+            foreach (var item1 in value)
+            {
+                Assert.True(model.Locale[item.Key].TryGetValue(item1.Key, out var value1));
+
+                Assert.True(JsonElement.DeepEquals(value1, model.Locale[item.Key][item1.Key]));
+            }
+        }
+        Assert.NotNull(model.Override);
+        Assert.Equal(expectedOverride.Count, model.Override.Count);
+        foreach (var item in expectedOverride)
+        {
+            Assert.True(model.Override.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, model.Override[item.Key]));
+        }
+        Assert.Equal(expectedTemplate, model.Template);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<InboundBulkMessage>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<InboundBulkMessage>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        string expectedEvent = "event";
+        string expectedBrand = "brand";
+        Content expectedContent = new ElementalContentSugar() { Body = "body", Title = "title" };
+        Dictionary<string, JsonElement> expectedData = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        Dictionary<string, Dictionary<string, JsonElement>> expectedLocale = new()
+        {
+            {
+                "foo",
+                new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                }
+            },
+        };
+        Dictionary<string, JsonElement> expectedOverride = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedTemplate = "template";
+
+        Assert.Equal(expectedEvent, deserialized.Event);
+        Assert.Equal(expectedBrand, deserialized.Brand);
+        Assert.Equal(expectedContent, deserialized.Content);
+        Assert.NotNull(deserialized.Data);
+        Assert.Equal(expectedData.Count, deserialized.Data.Count);
+        foreach (var item in expectedData)
+        {
+            Assert.True(deserialized.Data.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, deserialized.Data[item.Key]));
+        }
+        Assert.NotNull(deserialized.Locale);
+        Assert.Equal(expectedLocale.Count, deserialized.Locale.Count);
+        foreach (var item in expectedLocale)
+        {
+            Assert.True(deserialized.Locale.TryGetValue(item.Key, out var value));
+
+            Assert.Equal(value.Count, deserialized.Locale[item.Key].Count);
+            foreach (var item1 in value)
+            {
+                Assert.True(deserialized.Locale[item.Key].TryGetValue(item1.Key, out var value1));
+
+                Assert.True(
+                    JsonElement.DeepEquals(value1, deserialized.Locale[item.Key][item1.Key])
+                );
+            }
+        }
+        Assert.NotNull(deserialized.Override);
+        Assert.Equal(expectedOverride.Count, deserialized.Override.Count);
+        foreach (var item in expectedOverride)
+        {
+            Assert.True(deserialized.Override.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, deserialized.Override[item.Key]));
+        }
+        Assert.Equal(expectedTemplate, deserialized.Template);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new InboundBulkMessage { Event = "event" };
+
+        Assert.Null(model.Brand);
+        Assert.False(model.RawData.ContainsKey("brand"));
+        Assert.Null(model.Content);
+        Assert.False(model.RawData.ContainsKey("content"));
+        Assert.Null(model.Data);
+        Assert.False(model.RawData.ContainsKey("data"));
+        Assert.Null(model.Locale);
+        Assert.False(model.RawData.ContainsKey("locale"));
+        Assert.Null(model.Override);
+        Assert.False(model.RawData.ContainsKey("override"));
+        Assert.Null(model.Template);
+        Assert.False(model.RawData.ContainsKey("template"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new InboundBulkMessage { Event = "event" };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullAreSetToNull_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+
+            Brand = null,
+            Content = null,
+            Data = null,
+            Locale = null,
+            Override = null,
+            Template = null,
+        };
+
+        Assert.Null(model.Brand);
+        Assert.True(model.RawData.ContainsKey("brand"));
+        Assert.Null(model.Content);
+        Assert.True(model.RawData.ContainsKey("content"));
+        Assert.Null(model.Data);
+        Assert.True(model.RawData.ContainsKey("data"));
+        Assert.Null(model.Locale);
+        Assert.True(model.RawData.ContainsKey("locale"));
+        Assert.Null(model.Override);
+        Assert.True(model.RawData.ContainsKey("override"));
+        Assert.Null(model.Template);
+        Assert.True(model.RawData.ContainsKey("template"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+
+            Brand = null,
+            Content = null,
+            Data = null,
+            Locale = null,
+            Override = null,
+            Template = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new InboundBulkMessage
+        {
+            Event = "event",
+            Brand = "brand",
+            Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+            {
+                {
+                    "foo",
+                    new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    }
+                },
+            },
+            Override = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Template = "template",
+        };
+
+        InboundBulkMessage copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}
+
+public class ContentTest : TestBase
+{
+    [Fact]
+    public void ElementalContentSugarValidationWorks()
+    {
+        Content value = new ElementalContentSugar() { Body = "body", Title = "title" };
+        value.Validate();
+    }
+
+    [Fact]
+    public void ElementalValidationWorks()
+    {
+        Content value = new ElementalContent()
+        {
+            Elements =
+            [
+                new ElementalTextNodeWithType()
+                {
+                    Channels = ["string"],
+                    If = "if",
+                    Loop = "loop",
+                    Ref = "ref",
+                    Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
+                },
+            ],
+            Version = "version",
+        };
+        value.Validate();
+    }
+
+    [Fact]
+    public void ElementalContentSugarSerializationRoundtripWorks()
+    {
+        Content value = new ElementalContentSugar() { Body = "body", Title = "title" };
+        string element = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Content>(
+            element,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+
+    [Fact]
+    public void ElementalSerializationRoundtripWorks()
+    {
+        Content value = new ElementalContent()
+        {
+            Elements =
+            [
+                new ElementalTextNodeWithType()
+                {
+                    Channels = ["string"],
+                    If = "if",
+                    Loop = "loop",
+                    Ref = "ref",
+                    Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
+                },
+            ],
+            Version = "version",
+        };
+        string element = JsonSerializer.Serialize(value, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<Content>(
+            element,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(value, deserialized);
+    }
+}

--- a/src/TryCourier.Tests/Models/Bulk/InboundBulkMessageUserTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/InboundBulkMessageUserTest.cs
@@ -1,0 +1,1071 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Models;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Tests.Models.Bulk;
+
+public class InboundBulkMessageUserTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        JsonElement expectedData = JsonSerializer.Deserialize<JsonElement>("{}");
+        RecipientPreferences expectedPreferences = new()
+        {
+            Categories = new Dictionary<string, NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+            Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+        };
+        Dictionary<string, JsonElement> expectedProfile = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedRecipient = "recipient";
+        UserRecipient expectedTo = new()
+        {
+            AccountID = "account_id",
+            Context = new() { TenantID = "tenant_id" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Email = "email",
+            ListID = "list_id",
+            Locale = "locale",
+            PhoneNumber = "phone_number",
+            Preferences = new()
+            {
+                Notifications = new Dictionary<string, Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Source.Subscription,
+                        }
+                    },
+                },
+                Categories = new Dictionary<string, Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Source.Subscription,
+                        }
+                    },
+                },
+                TemplateID = "templateId",
+            },
+            TenantID = "tenant_id",
+            UserID = "user_id",
+        };
+
+        Assert.NotNull(model.Data);
+        Assert.True(JsonElement.DeepEquals(expectedData, model.Data.Value));
+        Assert.Equal(expectedPreferences, model.Preferences);
+        Assert.NotNull(model.Profile);
+        Assert.Equal(expectedProfile.Count, model.Profile.Count);
+        foreach (var item in expectedProfile)
+        {
+            Assert.True(model.Profile.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, model.Profile[item.Key]));
+        }
+        Assert.Equal(expectedRecipient, model.Recipient);
+        Assert.Equal(expectedTo, model.To);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<InboundBulkMessageUser>(
+            json,
+            ModelBase.SerializerOptions
+        );
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<InboundBulkMessageUser>(
+            element,
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(deserialized);
+
+        JsonElement expectedData = JsonSerializer.Deserialize<JsonElement>("{}");
+        RecipientPreferences expectedPreferences = new()
+        {
+            Categories = new Dictionary<string, NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+            Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+            {
+                {
+                    "foo",
+                    new()
+                    {
+                        Status = PreferenceStatus.OptedIn,
+                        ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                        Rules = [new() { Until = "until", Start = "start" }],
+                    }
+                },
+            },
+        };
+        Dictionary<string, JsonElement> expectedProfile = new()
+        {
+            { "foo", JsonSerializer.SerializeToElement("bar") },
+        };
+        string expectedRecipient = "recipient";
+        UserRecipient expectedTo = new()
+        {
+            AccountID = "account_id",
+            Context = new() { TenantID = "tenant_id" },
+            Data = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Email = "email",
+            ListID = "list_id",
+            Locale = "locale",
+            PhoneNumber = "phone_number",
+            Preferences = new()
+            {
+                Notifications = new Dictionary<string, Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Source.Subscription,
+                        }
+                    },
+                },
+                Categories = new Dictionary<string, Preference>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                            Source = Source.Subscription,
+                        }
+                    },
+                },
+                TemplateID = "templateId",
+            },
+            TenantID = "tenant_id",
+            UserID = "user_id",
+        };
+
+        Assert.NotNull(deserialized.Data);
+        Assert.True(JsonElement.DeepEquals(expectedData, deserialized.Data.Value));
+        Assert.Equal(expectedPreferences, deserialized.Preferences);
+        Assert.NotNull(deserialized.Profile);
+        Assert.Equal(expectedProfile.Count, deserialized.Profile.Count);
+        foreach (var item in expectedProfile)
+        {
+            Assert.True(deserialized.Profile.TryGetValue(item.Key, out var value));
+
+            Assert.True(JsonElement.DeepEquals(value, deserialized.Profile[item.Key]));
+        }
+        Assert.Equal(expectedRecipient, deserialized.Recipient);
+        Assert.Equal(expectedTo, deserialized.To);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        Assert.Null(model.Data);
+        Assert.False(model.RawData.ContainsKey("data"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullAreNotSet_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+
+            // Null should be interpreted as omitted for these properties
+            Data = null,
+        };
+
+        Assert.Null(model.Data);
+        Assert.False(model.RawData.ContainsKey("data"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+
+            // Null should be interpreted as omitted for these properties
+            Data = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+        };
+
+        Assert.Null(model.Preferences);
+        Assert.False(model.RawData.ContainsKey("preferences"));
+        Assert.Null(model.Profile);
+        Assert.False(model.RawData.ContainsKey("profile"));
+        Assert.Null(model.Recipient);
+        Assert.False(model.RawData.ContainsKey("recipient"));
+        Assert.Null(model.To);
+        Assert.False(model.RawData.ContainsKey("to"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullAreSetToNull_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+
+            Preferences = null,
+            Profile = null,
+            Recipient = null,
+            To = null,
+        };
+
+        Assert.Null(model.Preferences);
+        Assert.True(model.RawData.ContainsKey("preferences"));
+        Assert.Null(model.Profile);
+        Assert.True(model.RawData.ContainsKey("profile"));
+        Assert.Null(model.Recipient);
+        Assert.True(model.RawData.ContainsKey("recipient"));
+        Assert.Null(model.To);
+        Assert.True(model.RawData.ContainsKey("to"));
+    }
+
+    [Fact]
+    public void OptionalNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+
+            Preferences = null,
+            Profile = null,
+            Recipient = null,
+            To = null,
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new InboundBulkMessageUser
+        {
+            Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+            Preferences = new()
+            {
+                Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+                Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                {
+                    {
+                        "foo",
+                        new()
+                        {
+                            Status = PreferenceStatus.OptedIn,
+                            ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                            Rules = [new() { Until = "until", Start = "start" }],
+                        }
+                    },
+                },
+            },
+            Profile = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Recipient = "recipient",
+            To = new()
+            {
+                AccountID = "account_id",
+                Context = new() { TenantID = "tenant_id" },
+                Data = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Email = "email",
+                ListID = "list_id",
+                Locale = "locale",
+                PhoneNumber = "phone_number",
+                Preferences = new()
+                {
+                    Notifications = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    Categories = new Dictionary<string, Preference>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                                Source = Source.Subscription,
+                            }
+                        },
+                    },
+                    TemplateID = "templateId",
+                },
+                TenantID = "tenant_id",
+                UserID = "user_id",
+            },
+        };
+
+        InboundBulkMessageUser copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}

--- a/src/TryCourier.Tests/Services/BulkServiceTest.cs
+++ b/src/TryCourier.Tests/Services/BulkServiceTest.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using TryCourier.Models;
+
+namespace TryCourier.Tests.Services;
+
+public class BulkServiceTest : TestBase
+{
+    [Fact(Skip = "Mock server tests are disabled")]
+    public async Task AddUsers_Works()
+    {
+        await this.client.Bulk.AddUsers(
+            "job_id",
+            new()
+            {
+                Users =
+                [
+                    new()
+                    {
+                        Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                        Preferences = new()
+                        {
+                            Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                            Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                        },
+                        Profile = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Recipient = "recipient",
+                        To = new()
+                        {
+                            AccountID = "account_id",
+                            Context = new() { TenantID = "tenant_id" },
+                            Data = new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            },
+                            Email = "email",
+                            ListID = "list_id",
+                            Locale = "locale",
+                            PhoneNumber = "phone_number",
+                            Preferences = new()
+                            {
+                                Notifications = new Dictionary<string, Preference>()
+                                {
+                                    {
+                                        "foo",
+                                        new()
+                                        {
+                                            Status = PreferenceStatus.OptedIn,
+                                            ChannelPreferences =
+                                            [
+                                                new(ChannelClassification.DirectMessage),
+                                            ],
+                                            Rules = [new() { Until = "until", Start = "start" }],
+                                            Source = Source.Subscription,
+                                        }
+                                    },
+                                },
+                                Categories = new Dictionary<string, Preference>()
+                                {
+                                    {
+                                        "foo",
+                                        new()
+                                        {
+                                            Status = PreferenceStatus.OptedIn,
+                                            ChannelPreferences =
+                                            [
+                                                new(ChannelClassification.DirectMessage),
+                                            ],
+                                            Rules = [new() { Until = "until", Start = "start" }],
+                                            Source = Source.Subscription,
+                                        }
+                                    },
+                                },
+                                TemplateID = "templateId",
+                            },
+                            TenantID = "tenant_id",
+                            UserID = "user_id",
+                        },
+                    },
+                ],
+            },
+            TestContext.Current.CancellationToken
+        );
+    }
+
+    [Fact(Skip = "Mock server tests are disabled")]
+    public async Task CreateJob_Works()
+    {
+        var response = await this.client.Bulk.CreateJob(
+            new()
+            {
+                Message = new()
+                {
+                    Event = "event",
+                    Brand = "brand",
+                    Content = new ElementalContentSugar() { Body = "body", Title = "title" },
+                    Data = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
+                    {
+                        {
+                            "foo",
+                            new Dictionary<string, JsonElement>()
+                            {
+                                { "foo", JsonSerializer.SerializeToElement("bar") },
+                            }
+                        },
+                    },
+                    Override = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Template = "template",
+                },
+            },
+            TestContext.Current.CancellationToken
+        );
+        response.Validate();
+    }
+
+    [Fact(Skip = "Mock server tests are disabled")]
+    public async Task ListUsers_Works()
+    {
+        var response = await this.client.Bulk.ListUsers(
+            "job_id",
+            new(),
+            TestContext.Current.CancellationToken
+        );
+        response.Validate();
+    }
+
+    [Fact(Skip = "Mock server tests are disabled")]
+    public async Task RetrieveJob_Works()
+    {
+        var response = await this.client.Bulk.RetrieveJob(
+            "job_id",
+            new(),
+            TestContext.Current.CancellationToken
+        );
+        response.Validate();
+    }
+
+    [Fact(Skip = "Mock server tests are disabled")]
+    public async Task RunJob_Works()
+    {
+        await this.client.Bulk.RunJob("job_id", new(), TestContext.Current.CancellationToken);
+    }
+}

--- a/src/TryCourier/Core/ModelBase.cs
+++ b/src/TryCourier/Core/ModelBase.cs
@@ -3,7 +3,7 @@ using TryCourier.Exceptions;
 using TryCourier.Models;
 using TryCourier.Models.Automations;
 using TryCourier.Models.Brands;
-using TryCourier.Models.Messages;
+using TryCourier.Models.Bulk;
 using TryCourier.Models.WorkspacePreferences;
 using Audiences = TryCourier.Models.Audiences;
 using Broadcasts = TryCourier.Models.Broadcasts;
@@ -13,6 +13,7 @@ using Invoke = TryCourier.Models.Automations.Invoke;
 using Items = TryCourier.Models.Tenants.Preferences.Items;
 using Journeys = TryCourier.Models.Journeys;
 using Lists = TryCourier.Models.Profiles.Lists;
+using Messages = TryCourier.Models.Messages;
 using Notifications = TryCourier.Models.Notifications;
 using Profiles = TryCourier.Models.Profiles;
 using Send = TryCourier.Models.Send;
@@ -144,13 +145,15 @@ public abstract record class ModelBase
             new ApiEnumConverter<string, Broadcasts::Channel>(),
             new ApiEnumConverter<string, Broadcasts::RecipientType>(),
             new ApiEnumConverter<string, Broadcasts::BroadcastSendParamsRecipientType>(),
+            new ApiEnumConverter<string, Status>(),
+            new ApiEnumConverter<string, JobStatus>(),
             new ApiEnumConverter<string, Placement>(),
             new ApiEnumConverter<string, Digests::Retain>(),
             new ApiEnumConverter<string, Digests::Status>(),
             new ApiEnumConverter<string, Digests::Type>(),
             new ApiEnumConverter<string, Inbound::Type>(),
-            new ApiEnumConverter<string, Status>(),
-            new ApiEnumConverter<string, Reason>(),
+            new ApiEnumConverter<string, Messages::Status>(),
+            new ApiEnumConverter<string, Messages::Reason>(),
             new ApiEnumConverter<string, Notifications::Status>(),
             new ApiEnumConverter<string, Notifications::Type>(),
             new ApiEnumConverter<string, Notifications::BlockType>(),

--- a/src/TryCourier/CourierClient.cs
+++ b/src/TryCourier/CourierClient.cs
@@ -120,6 +120,12 @@ public sealed class CourierClient : ICourierClient
         get { return _broadcasts.Value; }
     }
 
+    readonly Lazy<IBulkService> _bulk;
+    public IBulkService Bulk
+    {
+        get { return _bulk.Value; }
+    }
+
     readonly Lazy<IBrandService> _brands;
     public IBrandService Brands
     {
@@ -213,6 +219,7 @@ public sealed class CourierClient : ICourierClient
         _automations = new(() => new AutomationService(this));
         _journeys = new(() => new JourneyService(this));
         _broadcasts = new(() => new BroadcastService(this));
+        _bulk = new(() => new BulkService(this));
         _brands = new(() => new BrandService(this));
         _digests = new(() => new DigestService(this));
         _inbound = new(() => new InboundService(this));
@@ -347,6 +354,12 @@ public sealed class CourierClientWithRawResponse : ICourierClientWithRawResponse
     public IBroadcastServiceWithRawResponse Broadcasts
     {
         get { return _broadcasts.Value; }
+    }
+
+    readonly Lazy<IBulkServiceWithRawResponse> _bulk;
+    public IBulkServiceWithRawResponse Bulk
+    {
+        get { return _bulk.Value; }
     }
 
     readonly Lazy<IBrandServiceWithRawResponse> _brands;
@@ -633,6 +646,7 @@ public sealed class CourierClientWithRawResponse : ICourierClientWithRawResponse
         _automations = new(() => new AutomationServiceWithRawResponse(this));
         _journeys = new(() => new JourneyServiceWithRawResponse(this));
         _broadcasts = new(() => new BroadcastServiceWithRawResponse(this));
+        _bulk = new(() => new BulkServiceWithRawResponse(this));
         _brands = new(() => new BrandServiceWithRawResponse(this));
         _digests = new(() => new DigestServiceWithRawResponse(this));
         _inbound = new(() => new InboundServiceWithRawResponse(this));

--- a/src/TryCourier/ICourierClient.cs
+++ b/src/TryCourier/ICourierClient.cs
@@ -67,6 +67,8 @@ public interface ICourierClient : IDisposable
 
     IBroadcastService Broadcasts { get; }
 
+    IBulkService Bulk { get; }
+
     IBrandService Brands { get; }
 
     IDigestService Digests { get; }
@@ -138,6 +140,8 @@ public interface ICourierClientWithRawResponse : IDisposable
     IJourneyServiceWithRawResponse Journeys { get; }
 
     IBroadcastServiceWithRawResponse Broadcasts { get; }
+
+    IBulkServiceWithRawResponse Bulk { get; }
 
     IBrandServiceWithRawResponse Brands { get; }
 

--- a/src/TryCourier/Models/Bulk/BulkAddUsersParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkAddUsersParams.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Ingest user data into a Bulk Job.
+///
+/// <para>**Important**: For email-based bulk jobs, each user must include `profile.email`
+///  for provider routing to work correctly. The `to.email` field is not sufficient
+///  for email provider routing.</para>
+///
+/// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
+/// breaking changes in non-major versions. We may add new methods in the future that
+/// cause existing derived classes to break.</para>
+/// </summary>
+public record class BulkAddUsersParams : ParamsBase
+{
+    readonly JsonDictionary _rawBodyData = new();
+    public IReadOnlyDictionary<string, JsonElement> RawBodyData
+    {
+        get { return this._rawBodyData.Freeze(); }
+    }
+
+    public string? JobID { get; init; }
+
+    public required IReadOnlyList<InboundBulkMessageUser> Users
+    {
+        get
+        {
+            this._rawBodyData.Freeze();
+            return this._rawBodyData.GetNotNullStruct<ImmutableArray<InboundBulkMessageUser>>(
+                "users"
+            );
+        }
+        init
+        {
+            this._rawBodyData.Set<ImmutableArray<InboundBulkMessageUser>>(
+                "users",
+                ImmutableArray.ToImmutableArray(value)
+            );
+        }
+    }
+
+    public BulkAddUsersParams() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkAddUsersParams(BulkAddUsersParams bulkAddUsersParams)
+        : base(bulkAddUsersParams)
+    {
+        this.JobID = bulkAddUsersParams.JobID;
+
+        this._rawBodyData = new(bulkAddUsersParams._rawBodyData);
+    }
+#pragma warning restore CS8618
+
+    public BulkAddUsersParams(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        IReadOnlyDictionary<string, JsonElement> rawBodyData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this._rawBodyData = new(rawBodyData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkAddUsersParams(
+        FrozenDictionary<string, JsonElement> rawHeaderData,
+        FrozenDictionary<string, JsonElement> rawQueryData,
+        FrozenDictionary<string, JsonElement> rawBodyData,
+        string jobID
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this._rawBodyData = new(rawBodyData);
+        this.JobID = jobID;
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IFromRawJson{T}.FromRawUnchecked"/>
+    public static BulkAddUsersParams FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        IReadOnlyDictionary<string, JsonElement> rawBodyData,
+        string jobID
+    )
+    {
+        return new(
+            FrozenDictionary.ToFrozenDictionary(rawHeaderData),
+            FrozenDictionary.ToFrozenDictionary(rawQueryData),
+            FrozenDictionary.ToFrozenDictionary(rawBodyData),
+            jobID
+        );
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(
+                new Dictionary<string, JsonElement>()
+                {
+                    ["JobID"] = JsonSerializer.SerializeToElement(this.JobID),
+                    ["HeaderData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawHeaderData.Freeze())
+                    ),
+                    ["QueryData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawQueryData.Freeze())
+                    ),
+                    ["BodyData"] = FriendlyJsonPrinter.PrintValue(this._rawBodyData.Freeze()),
+                }
+            ),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    public virtual bool Equals(BulkAddUsersParams? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        return (this.JobID?.Equals(other.JobID) ?? other.JobID == null)
+            && this._rawHeaderData.Equals(other._rawHeaderData)
+            && this._rawQueryData.Equals(other._rawQueryData)
+            && this._rawBodyData.Equals(other._rawBodyData);
+    }
+
+    public override Uri Url(ClientOptions options)
+    {
+        return new UriBuilder(
+            options.BaseUrl.ToString().TrimEnd('/') + string.Format("/bulk/{0}", this.JobID)
+        )
+        {
+            Query = this.QueryString(options),
+        }.Uri;
+    }
+
+    internal override HttpContent? BodyContent()
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(this.RawBodyData, ModelBase.SerializerOptions),
+            Encoding.UTF8,
+            "application/json"
+        );
+    }
+
+    internal override void AddHeadersToRequest(HttpRequestMessage request, ClientOptions options)
+    {
+        ParamsBase.AddDefaultHeaders(request, options);
+        foreach (var item in this.RawHeaderData)
+        {
+            ParamsBase.AddHeaderElementToRequest(request, item.Key, item.Value);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkCreateJobParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkCreateJobParams.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Creates a new bulk job for sending messages to multiple recipients.
+///
+/// <para>**Required**: `message.event` (event ID or notification ID)</para>
+///
+/// <para>**Optional (V2 format)**: `message.template` (notification ID) or `message.content`
+/// (Elemental content)  can be provided to override the notification associated
+/// with the event.</para>
+///
+/// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
+/// breaking changes in non-major versions. We may add new methods in the future that
+/// cause existing derived classes to break.</para>
+/// </summary>
+public record class BulkCreateJobParams : ParamsBase
+{
+    readonly JsonDictionary _rawBodyData = new();
+    public IReadOnlyDictionary<string, JsonElement> RawBodyData
+    {
+        get { return this._rawBodyData.Freeze(); }
+    }
+
+    /// <summary>
+    /// Bulk message definition. Supports two formats: - V1 format: Requires `event`
+    /// field (event ID or notification ID) - V2 format: Optionally use `template`
+    /// (notification ID) or `content` (Elemental content) in addition to `event`
+    /// </summary>
+    public required InboundBulkMessage Message
+    {
+        get
+        {
+            this._rawBodyData.Freeze();
+            return this._rawBodyData.GetNotNullClass<InboundBulkMessage>("message");
+        }
+        init { this._rawBodyData.Set("message", value); }
+    }
+
+    public BulkCreateJobParams() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkCreateJobParams(BulkCreateJobParams bulkCreateJobParams)
+        : base(bulkCreateJobParams)
+    {
+        this._rawBodyData = new(bulkCreateJobParams._rawBodyData);
+    }
+#pragma warning restore CS8618
+
+    public BulkCreateJobParams(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        IReadOnlyDictionary<string, JsonElement> rawBodyData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this._rawBodyData = new(rawBodyData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkCreateJobParams(
+        FrozenDictionary<string, JsonElement> rawHeaderData,
+        FrozenDictionary<string, JsonElement> rawQueryData,
+        FrozenDictionary<string, JsonElement> rawBodyData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this._rawBodyData = new(rawBodyData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IFromRawJson{T}.FromRawUnchecked"/>
+    public static BulkCreateJobParams FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        IReadOnlyDictionary<string, JsonElement> rawBodyData
+    )
+    {
+        return new(
+            FrozenDictionary.ToFrozenDictionary(rawHeaderData),
+            FrozenDictionary.ToFrozenDictionary(rawQueryData),
+            FrozenDictionary.ToFrozenDictionary(rawBodyData)
+        );
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(
+                new Dictionary<string, JsonElement>()
+                {
+                    ["HeaderData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawHeaderData.Freeze())
+                    ),
+                    ["QueryData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawQueryData.Freeze())
+                    ),
+                    ["BodyData"] = FriendlyJsonPrinter.PrintValue(this._rawBodyData.Freeze()),
+                }
+            ),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    public virtual bool Equals(BulkCreateJobParams? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        return this._rawHeaderData.Equals(other._rawHeaderData)
+            && this._rawQueryData.Equals(other._rawQueryData)
+            && this._rawBodyData.Equals(other._rawBodyData);
+    }
+
+    public override Uri Url(ClientOptions options)
+    {
+        return new UriBuilder(options.BaseUrl.ToString().TrimEnd('/') + "/bulk")
+        {
+            Query = this.QueryString(options),
+        }.Uri;
+    }
+
+    internal override HttpContent? BodyContent()
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(this.RawBodyData, ModelBase.SerializerOptions),
+            Encoding.UTF8,
+            "application/json"
+        );
+    }
+
+    internal override void AddHeadersToRequest(HttpRequestMessage request, ClientOptions options)
+    {
+        ParamsBase.AddDefaultHeaders(request, options);
+        foreach (var item in this.RawHeaderData)
+        {
+            ParamsBase.AddHeaderElementToRequest(request, item.Key, item.Value);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkCreateJobResponse.cs
+++ b/src/TryCourier/Models/Bulk/BulkCreateJobResponse.cs
@@ -1,0 +1,72 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+[JsonConverter(typeof(JsonModelConverter<BulkCreateJobResponse, BulkCreateJobResponseFromRaw>))]
+public sealed record class BulkCreateJobResponse : JsonModel
+{
+    public required string JobID
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<string>("jobId");
+        }
+        init { this._rawData.Set("jobId", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        _ = this.JobID;
+    }
+
+    public BulkCreateJobResponse() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkCreateJobResponse(BulkCreateJobResponse bulkCreateJobResponse)
+        : base(bulkCreateJobResponse) { }
+#pragma warning restore CS8618
+
+    public BulkCreateJobResponse(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkCreateJobResponse(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="BulkCreateJobResponseFromRaw.FromRawUnchecked"/>
+    public static BulkCreateJobResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public BulkCreateJobResponse(string jobID)
+        : this()
+    {
+        this.JobID = jobID;
+    }
+}
+
+class BulkCreateJobResponseFromRaw : IFromRawJson<BulkCreateJobResponse>
+{
+    /// <inheritdoc/>
+    public BulkCreateJobResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    ) => BulkCreateJobResponse.FromRawUnchecked(rawData);
+}

--- a/src/TryCourier/Models/Bulk/BulkListUsersParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkListUsersParams.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.Json;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Get Bulk Job Users
+///
+/// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
+/// breaking changes in non-major versions. We may add new methods in the future that
+/// cause existing derived classes to break.</para>
+/// </summary>
+public record class BulkListUsersParams : ParamsBase
+{
+    public string? JobID { get; init; }
+
+    /// <summary>
+    /// A unique identifier that allows for fetching the next set of users added to
+    /// the bulk job
+    /// </summary>
+    public string? Cursor
+    {
+        get
+        {
+            this._rawQueryData.Freeze();
+            return this._rawQueryData.GetNullableClass<string>("cursor");
+        }
+        init { this._rawQueryData.Set("cursor", value); }
+    }
+
+    public BulkListUsersParams() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkListUsersParams(BulkListUsersParams bulkListUsersParams)
+        : base(bulkListUsersParams)
+    {
+        this.JobID = bulkListUsersParams.JobID;
+    }
+#pragma warning restore CS8618
+
+    public BulkListUsersParams(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkListUsersParams(
+        FrozenDictionary<string, JsonElement> rawHeaderData,
+        FrozenDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this.JobID = jobID;
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IFromRawJson{T}.FromRawUnchecked"/>
+    public static BulkListUsersParams FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        return new(
+            FrozenDictionary.ToFrozenDictionary(rawHeaderData),
+            FrozenDictionary.ToFrozenDictionary(rawQueryData),
+            jobID
+        );
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(
+                new Dictionary<string, JsonElement>()
+                {
+                    ["JobID"] = JsonSerializer.SerializeToElement(this.JobID),
+                    ["HeaderData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawHeaderData.Freeze())
+                    ),
+                    ["QueryData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawQueryData.Freeze())
+                    ),
+                }
+            ),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    public virtual bool Equals(BulkListUsersParams? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        return (this.JobID?.Equals(other.JobID) ?? other.JobID == null)
+            && this._rawHeaderData.Equals(other._rawHeaderData)
+            && this._rawQueryData.Equals(other._rawQueryData);
+    }
+
+    public override Uri Url(ClientOptions options)
+    {
+        return new UriBuilder(
+            options.BaseUrl.ToString().TrimEnd('/') + string.Format("/bulk/{0}/users", this.JobID)
+        )
+        {
+            Query = this.QueryString(options),
+        }.Uri;
+    }
+
+    internal override void AddHeadersToRequest(HttpRequestMessage request, ClientOptions options)
+    {
+        ParamsBase.AddDefaultHeaders(request, options);
+        foreach (var item in this.RawHeaderData)
+        {
+            ParamsBase.AddHeaderElementToRequest(request, item.Key, item.Value);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkListUsersResponse.cs
+++ b/src/TryCourier/Models/Bulk/BulkListUsersResponse.cs
@@ -1,0 +1,383 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using System = System;
+
+namespace TryCourier.Models.Bulk;
+
+[JsonConverter(typeof(JsonModelConverter<BulkListUsersResponse, BulkListUsersResponseFromRaw>))]
+public sealed record class BulkListUsersResponse : JsonModel
+{
+    public required IReadOnlyList<Item> Items
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullStruct<ImmutableArray<Item>>("items");
+        }
+        init
+        {
+            this._rawData.Set<ImmutableArray<Item>>(
+                "items",
+                ImmutableArray.ToImmutableArray(value)
+            );
+        }
+    }
+
+    public required Paging Paging
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<Paging>("paging");
+        }
+        init { this._rawData.Set("paging", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        foreach (var item in this.Items)
+        {
+            item.Validate();
+        }
+        this.Paging.Validate();
+    }
+
+    public BulkListUsersResponse() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkListUsersResponse(BulkListUsersResponse bulkListUsersResponse)
+        : base(bulkListUsersResponse) { }
+#pragma warning restore CS8618
+
+    public BulkListUsersResponse(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkListUsersResponse(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="BulkListUsersResponseFromRaw.FromRawUnchecked"/>
+    public static BulkListUsersResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+}
+
+class BulkListUsersResponseFromRaw : IFromRawJson<BulkListUsersResponse>
+{
+    /// <inheritdoc/>
+    public BulkListUsersResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    ) => BulkListUsersResponse.FromRawUnchecked(rawData);
+}
+
+[JsonConverter(typeof(JsonModelConverter<Item, ItemFromRaw>))]
+public sealed record class Item : JsonModel
+{
+    /// <summary>
+    /// User-specific data that will be merged with message.data
+    /// </summary>
+    public JsonElement? Data
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableStruct<JsonElement>("data");
+        }
+        init
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this._rawData.Set("data", value);
+        }
+    }
+
+    public RecipientPreferences? Preferences
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<RecipientPreferences>("preferences");
+        }
+        init
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this._rawData.Set("preferences", value);
+        }
+    }
+
+    /// <summary>
+    /// User profile information. For email-based bulk jobs, `profile.email` is required
+    ///  for provider routing to determine if the message can be delivered. The email
+    ///  address should be provided here rather than in `to.email`.
+    /// </summary>
+    public IReadOnlyDictionary<string, JsonElement>? Profile
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<FrozenDictionary<string, JsonElement>>("profile");
+        }
+        init
+        {
+            this._rawData.Set<FrozenDictionary<string, JsonElement>?>(
+                "profile",
+                value == null ? null : FrozenDictionary.ToFrozenDictionary(value)
+            );
+        }
+    }
+
+    /// <summary>
+    /// User ID (legacy field, use profile or to.user_id instead)
+    /// </summary>
+    public string? Recipient
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("recipient");
+        }
+        init { this._rawData.Set("recipient", value); }
+    }
+
+    public UserRecipient? To
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<UserRecipient>("to");
+        }
+        init
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this._rawData.Set("to", value);
+        }
+    }
+
+    public required ApiEnum<string, Status> Status
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<ApiEnum<string, Status>>("status");
+        }
+        init { this._rawData.Set("status", value); }
+    }
+
+    public string? MessageID
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("messageId");
+        }
+        init { this._rawData.Set("messageId", value); }
+    }
+
+    public static implicit operator InboundBulkMessageUser(Item item) =>
+        new()
+        {
+            Data = item.Data,
+            Preferences = item.Preferences,
+            Profile = item.Profile,
+            Recipient = item.Recipient,
+            To = item.To,
+        };
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        _ = this.Data;
+        this.Preferences?.Validate();
+        _ = this.Profile;
+        _ = this.Recipient;
+        this.To?.Validate();
+        this.Status.Validate();
+        _ = this.MessageID;
+    }
+
+    public Item() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public Item(Item item)
+        : base(item) { }
+#pragma warning restore CS8618
+
+    public Item(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    Item(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="ItemFromRaw.FromRawUnchecked"/>
+    public static Item FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public Item(ApiEnum<string, Status> status)
+        : this()
+    {
+        this.Status = status;
+    }
+}
+
+class ItemFromRaw : IFromRawJson<Item>
+{
+    /// <inheritdoc/>
+    public Item FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData) =>
+        Item.FromRawUnchecked(rawData);
+}
+
+[JsonConverter(typeof(JsonModelConverter<IntersectionMember1, IntersectionMember1FromRaw>))]
+public sealed record class IntersectionMember1 : JsonModel
+{
+    public required ApiEnum<string, Status> Status
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<ApiEnum<string, Status>>("status");
+        }
+        init { this._rawData.Set("status", value); }
+    }
+
+    public string? MessageID
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("messageId");
+        }
+        init { this._rawData.Set("messageId", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        this.Status.Validate();
+        _ = this.MessageID;
+    }
+
+    public IntersectionMember1() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public IntersectionMember1(IntersectionMember1 intersectionMember1)
+        : base(intersectionMember1) { }
+#pragma warning restore CS8618
+
+    public IntersectionMember1(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    IntersectionMember1(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IntersectionMember1FromRaw.FromRawUnchecked"/>
+    public static IntersectionMember1 FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public IntersectionMember1(ApiEnum<string, Status> status)
+        : this()
+    {
+        this.Status = status;
+    }
+}
+
+class IntersectionMember1FromRaw : IFromRawJson<IntersectionMember1>
+{
+    /// <inheritdoc/>
+    public IntersectionMember1 FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData) =>
+        IntersectionMember1.FromRawUnchecked(rawData);
+}
+
+[JsonConverter(typeof(StatusConverter))]
+public enum Status
+{
+    Pending,
+    Enqueued,
+    Error,
+}
+
+sealed class StatusConverter : JsonConverter<Status>
+{
+    public override Status Read(
+        ref Utf8JsonReader reader,
+        System::Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        return JsonSerializer.Deserialize<string>(ref reader, options) switch
+        {
+            "PENDING" => Status.Pending,
+            "ENQUEUED" => Status.Enqueued,
+            "ERROR" => Status.Error,
+            _ => (Status)(-1),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, Status value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(
+            writer,
+            value switch
+            {
+                Status.Pending => "PENDING",
+                Status.Enqueued => "ENQUEUED",
+                Status.Error => "ERROR",
+                _ => throw new CourierInvalidDataException(
+                    string.Format("Invalid value '{0}' in {1}", value, nameof(value))
+                ),
+            },
+            options
+        );
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.Json;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Get a bulk job
+///
+/// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
+/// breaking changes in non-major versions. We may add new methods in the future that
+/// cause existing derived classes to break.</para>
+/// </summary>
+public record class BulkRetrieveJobParams : ParamsBase
+{
+    public string? JobID { get; init; }
+
+    public BulkRetrieveJobParams() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkRetrieveJobParams(BulkRetrieveJobParams bulkRetrieveJobParams)
+        : base(bulkRetrieveJobParams)
+    {
+        this.JobID = bulkRetrieveJobParams.JobID;
+    }
+#pragma warning restore CS8618
+
+    public BulkRetrieveJobParams(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkRetrieveJobParams(
+        FrozenDictionary<string, JsonElement> rawHeaderData,
+        FrozenDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this.JobID = jobID;
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IFromRawJson{T}.FromRawUnchecked"/>
+    public static BulkRetrieveJobParams FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        return new(
+            FrozenDictionary.ToFrozenDictionary(rawHeaderData),
+            FrozenDictionary.ToFrozenDictionary(rawQueryData),
+            jobID
+        );
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(
+                new Dictionary<string, JsonElement>()
+                {
+                    ["JobID"] = JsonSerializer.SerializeToElement(this.JobID),
+                    ["HeaderData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawHeaderData.Freeze())
+                    ),
+                    ["QueryData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawQueryData.Freeze())
+                    ),
+                }
+            ),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    public virtual bool Equals(BulkRetrieveJobParams? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        return (this.JobID?.Equals(other.JobID) ?? other.JobID == null)
+            && this._rawHeaderData.Equals(other._rawHeaderData)
+            && this._rawQueryData.Equals(other._rawQueryData);
+    }
+
+    public override Uri Url(ClientOptions options)
+    {
+        return new UriBuilder(
+            options.BaseUrl.ToString().TrimEnd('/') + string.Format("/bulk/{0}", this.JobID)
+        )
+        {
+            Query = this.QueryString(options),
+        }.Uri;
+    }
+
+    internal override void AddHeadersToRequest(HttpRequestMessage request, ClientOptions options)
+    {
+        ParamsBase.AddDefaultHeaders(request, options);
+        foreach (var item in this.RawHeaderData)
+        {
+            ParamsBase.AddHeaderElementToRequest(request, item.Key, item.Value);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkRetrieveJobResponse.cs
+++ b/src/TryCourier/Models/Bulk/BulkRetrieveJobResponse.cs
@@ -1,0 +1,227 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using System = System;
+
+namespace TryCourier.Models.Bulk;
+
+[JsonConverter(typeof(JsonModelConverter<BulkRetrieveJobResponse, BulkRetrieveJobResponseFromRaw>))]
+public sealed record class BulkRetrieveJobResponse : JsonModel
+{
+    public required Job Job
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<Job>("job");
+        }
+        init { this._rawData.Set("job", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        this.Job.Validate();
+    }
+
+    public BulkRetrieveJobResponse() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkRetrieveJobResponse(BulkRetrieveJobResponse bulkRetrieveJobResponse)
+        : base(bulkRetrieveJobResponse) { }
+#pragma warning restore CS8618
+
+    public BulkRetrieveJobResponse(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkRetrieveJobResponse(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="BulkRetrieveJobResponseFromRaw.FromRawUnchecked"/>
+    public static BulkRetrieveJobResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public BulkRetrieveJobResponse(Job job)
+        : this()
+    {
+        this.Job = job;
+    }
+}
+
+class BulkRetrieveJobResponseFromRaw : IFromRawJson<BulkRetrieveJobResponse>
+{
+    /// <inheritdoc/>
+    public BulkRetrieveJobResponse FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    ) => BulkRetrieveJobResponse.FromRawUnchecked(rawData);
+}
+
+[JsonConverter(typeof(JsonModelConverter<Job, JobFromRaw>))]
+public sealed record class Job : JsonModel
+{
+    /// <summary>
+    /// Bulk message definition. Supports two formats: - V1 format: Requires `event`
+    /// field (event ID or notification ID) - V2 format: Optionally use `template`
+    /// (notification ID) or `content` (Elemental content) in addition to `event`
+    /// </summary>
+    public required InboundBulkMessage Definition
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<InboundBulkMessage>("definition");
+        }
+        init { this._rawData.Set("definition", value); }
+    }
+
+    public required long Enqueued
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullStruct<long>("enqueued");
+        }
+        init { this._rawData.Set("enqueued", value); }
+    }
+
+    public required long Failures
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullStruct<long>("failures");
+        }
+        init { this._rawData.Set("failures", value); }
+    }
+
+    public required long Received
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullStruct<long>("received");
+        }
+        init { this._rawData.Set("received", value); }
+    }
+
+    public required ApiEnum<string, JobStatus> Status
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<ApiEnum<string, JobStatus>>("status");
+        }
+        init { this._rawData.Set("status", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        this.Definition.Validate();
+        _ = this.Enqueued;
+        _ = this.Failures;
+        _ = this.Received;
+        this.Status.Validate();
+    }
+
+    public Job() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public Job(Job job)
+        : base(job) { }
+#pragma warning restore CS8618
+
+    public Job(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    Job(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="JobFromRaw.FromRawUnchecked"/>
+    public static Job FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+}
+
+class JobFromRaw : IFromRawJson<Job>
+{
+    /// <inheritdoc/>
+    public Job FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData) =>
+        Job.FromRawUnchecked(rawData);
+}
+
+[JsonConverter(typeof(JobStatusConverter))]
+public enum JobStatus
+{
+    Created,
+    Processing,
+    Completed,
+    Error,
+}
+
+sealed class JobStatusConverter : JsonConverter<JobStatus>
+{
+    public override JobStatus Read(
+        ref Utf8JsonReader reader,
+        System::Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        return JsonSerializer.Deserialize<string>(ref reader, options) switch
+        {
+            "CREATED" => JobStatus.Created,
+            "PROCESSING" => JobStatus.Processing,
+            "COMPLETED" => JobStatus.Completed,
+            "ERROR" => JobStatus.Error,
+            _ => (JobStatus)(-1),
+        };
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        JobStatus value,
+        JsonSerializerOptions options
+    )
+    {
+        JsonSerializer.Serialize(
+            writer,
+            value switch
+            {
+                JobStatus.Created => "CREATED",
+                JobStatus.Processing => "PROCESSING",
+                JobStatus.Completed => "COMPLETED",
+                JobStatus.Error => "ERROR",
+                _ => throw new CourierInvalidDataException(
+                    string.Format("Invalid value '{0}' in {1}", value, nameof(value))
+                ),
+            },
+            options
+        );
+    }
+}

--- a/src/TryCourier/Models/Bulk/BulkRunJobParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkRunJobParams.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Text.Json;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Run a bulk job
+///
+/// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
+/// breaking changes in non-major versions. We may add new methods in the future that
+/// cause existing derived classes to break.</para>
+/// </summary>
+public record class BulkRunJobParams : ParamsBase
+{
+    public string? JobID { get; init; }
+
+    public BulkRunJobParams() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public BulkRunJobParams(BulkRunJobParams bulkRunJobParams)
+        : base(bulkRunJobParams)
+    {
+        this.JobID = bulkRunJobParams.JobID;
+    }
+#pragma warning restore CS8618
+
+    public BulkRunJobParams(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    BulkRunJobParams(
+        FrozenDictionary<string, JsonElement> rawHeaderData,
+        FrozenDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        this._rawHeaderData = new(rawHeaderData);
+        this._rawQueryData = new(rawQueryData);
+        this.JobID = jobID;
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="IFromRawJson{T}.FromRawUnchecked"/>
+    public static BulkRunJobParams FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawHeaderData,
+        IReadOnlyDictionary<string, JsonElement> rawQueryData,
+        string jobID
+    )
+    {
+        return new(
+            FrozenDictionary.ToFrozenDictionary(rawHeaderData),
+            FrozenDictionary.ToFrozenDictionary(rawQueryData),
+            jobID
+        );
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(
+                new Dictionary<string, JsonElement>()
+                {
+                    ["JobID"] = JsonSerializer.SerializeToElement(this.JobID),
+                    ["HeaderData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawHeaderData.Freeze())
+                    ),
+                    ["QueryData"] = FriendlyJsonPrinter.PrintValue(
+                        JsonSerializer.SerializeToElement(this._rawQueryData.Freeze())
+                    ),
+                }
+            ),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    public virtual bool Equals(BulkRunJobParams? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        return (this.JobID?.Equals(other.JobID) ?? other.JobID == null)
+            && this._rawHeaderData.Equals(other._rawHeaderData)
+            && this._rawQueryData.Equals(other._rawQueryData);
+    }
+
+    public override Uri Url(ClientOptions options)
+    {
+        return new UriBuilder(
+            options.BaseUrl.ToString().TrimEnd('/') + string.Format("/bulk/{0}/run", this.JobID)
+        )
+        {
+            Query = this.QueryString(options),
+        }.Uri;
+    }
+
+    internal override void AddHeadersToRequest(HttpRequestMessage request, ClientOptions options)
+    {
+        ParamsBase.AddDefaultHeaders(request, options);
+        foreach (var item in this.RawHeaderData)
+        {
+            ParamsBase.AddHeaderElementToRequest(request, item.Key, item.Value);
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+}

--- a/src/TryCourier/Models/Bulk/InboundBulkMessage.cs
+++ b/src/TryCourier/Models/Bulk/InboundBulkMessage.cs
@@ -1,0 +1,448 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using System = System;
+
+namespace TryCourier.Models.Bulk;
+
+/// <summary>
+/// Bulk message definition. Supports two formats: - V1 format: Requires `event` field
+/// (event ID or notification ID) - V2 format: Optionally use `template` (notification
+/// ID) or `content` (Elemental content) in addition to `event`
+/// </summary>
+[JsonConverter(typeof(JsonModelConverter<InboundBulkMessage, InboundBulkMessageFromRaw>))]
+public sealed record class InboundBulkMessage : JsonModel
+{
+    /// <summary>
+    /// Event ID or Notification ID (required). Can be either a  Notification ID
+    /// (e.g., "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a custom Event ID  (e.g., "welcome-email")
+    /// mapped to a notification.
+    /// </summary>
+    public required string Event
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<string>("event");
+        }
+        init { this._rawData.Set("event", value); }
+    }
+
+    public string? Brand
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("brand");
+        }
+        init { this._rawData.Set("brand", value); }
+    }
+
+    /// <summary>
+    /// Elemental content (optional, for V2 format). When provided, this will be used
+    ///  instead of the notification associated with the `event` field.
+    /// </summary>
+    public Content? Content
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<Content>("content");
+        }
+        init { this._rawData.Set("content", value); }
+    }
+
+    public IReadOnlyDictionary<string, JsonElement>? Data
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<FrozenDictionary<string, JsonElement>>("data");
+        }
+        init
+        {
+            this._rawData.Set<FrozenDictionary<string, JsonElement>?>(
+                "data",
+                value == null ? null : FrozenDictionary.ToFrozenDictionary(value)
+            );
+        }
+    }
+
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, JsonElement>>? Locale
+    {
+        get
+        {
+            this._rawData.Freeze();
+            var value = this._rawData.GetNullableClass<
+                FrozenDictionary<string, FrozenDictionary<string, JsonElement>>
+            >("locale");
+            if (value == null)
+            {
+                return null;
+            }
+
+            return FrozenDictionary.ToFrozenDictionary(
+                value,
+                entry => entry.Key,
+                (entry) => (IReadOnlyDictionary<string, JsonElement>)entry.Value
+            );
+        }
+        init
+        {
+            this._rawData.Set<FrozenDictionary<string, FrozenDictionary<string, JsonElement>>?>(
+                "locale",
+                value == null
+                    ? null
+                    : FrozenDictionary.ToFrozenDictionary(
+                        value,
+                        entry => entry.Key,
+                        (entry) => FrozenDictionary.ToFrozenDictionary(entry.Value)
+                    )
+            );
+        }
+    }
+
+    public IReadOnlyDictionary<string, JsonElement>? Override
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<FrozenDictionary<string, JsonElement>>(
+                "override"
+            );
+        }
+        init
+        {
+            this._rawData.Set<FrozenDictionary<string, JsonElement>?>(
+                "override",
+                value == null ? null : FrozenDictionary.ToFrozenDictionary(value)
+            );
+        }
+    }
+
+    /// <summary>
+    /// Notification ID or template ID (optional, for V2 format). When provided,
+    /// this will be used instead of the notification associated with the `event`
+    /// field.
+    /// </summary>
+    public string? Template
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("template");
+        }
+        init { this._rawData.Set("template", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        _ = this.Event;
+        _ = this.Brand;
+        this.Content?.Validate();
+        _ = this.Data;
+        _ = this.Locale;
+        _ = this.Override;
+        _ = this.Template;
+    }
+
+    public InboundBulkMessage() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public InboundBulkMessage(InboundBulkMessage inboundBulkMessage)
+        : base(inboundBulkMessage) { }
+#pragma warning restore CS8618
+
+    public InboundBulkMessage(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    InboundBulkMessage(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="InboundBulkMessageFromRaw.FromRawUnchecked"/>
+    public static InboundBulkMessage FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public InboundBulkMessage(string event_)
+        : this()
+    {
+        this.Event = event_;
+    }
+}
+
+class InboundBulkMessageFromRaw : IFromRawJson<InboundBulkMessage>
+{
+    /// <inheritdoc/>
+    public InboundBulkMessage FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData) =>
+        InboundBulkMessage.FromRawUnchecked(rawData);
+}
+
+/// <summary>
+/// Elemental content (optional, for V2 format). When provided, this will be used
+///  instead of the notification associated with the `event` field.
+/// </summary>
+[JsonConverter(typeof(ContentConverter))]
+public record class Content : ModelBase
+{
+    public object? Value { get; } = null;
+
+    JsonElement? _element = null;
+
+    public JsonElement Json
+    {
+        get
+        {
+            return this._element ??= JsonSerializer.SerializeToElement(
+                this.Value,
+                ModelBase.SerializerOptions
+            );
+        }
+    }
+
+    public Content(ElementalContentSugar value, JsonElement? element = null)
+    {
+        this.Value = value;
+        this._element = element;
+    }
+
+    public Content(ElementalContent value, JsonElement? element = null)
+    {
+        this.Value = value;
+        this._element = element;
+    }
+
+    public Content(JsonElement element)
+    {
+        this._element = element;
+    }
+
+    /// <summary>
+    /// Returns true and sets the <c>out</c> parameter if the instance was constructed with a variant of
+    /// type <see cref="ElementalContentSugar"/>.
+    ///
+    /// <para>Consider using <see cref="Switch"/> or <see cref="Match"/> if you need to handle every variant.</para>
+    ///
+    /// <example>
+    /// <code>
+    /// if (instance.TryPickElementalContentSugar(out var value)) {
+    ///     // `value` is of type `ElementalContentSugar`
+    ///     Console.WriteLine(value);
+    /// }
+    /// </code>
+    /// </example>
+    /// </summary>
+    public bool TryPickElementalContentSugar([NotNullWhen(true)] out ElementalContentSugar? value)
+    {
+        value = this.Value as ElementalContentSugar;
+        return value != null;
+    }
+
+    /// <summary>
+    /// Returns true and sets the <c>out</c> parameter if the instance was constructed with a variant of
+    /// type <see cref="ElementalContent"/>.
+    ///
+    /// <para>Consider using <see cref="Switch"/> or <see cref="Match"/> if you need to handle every variant.</para>
+    ///
+    /// <example>
+    /// <code>
+    /// if (instance.TryPickElemental(out var value)) {
+    ///     // `value` is of type `ElementalContent`
+    ///     Console.WriteLine(value);
+    /// }
+    /// </code>
+    /// </example>
+    /// </summary>
+    public bool TryPickElemental([NotNullWhen(true)] out ElementalContent? value)
+    {
+        value = this.Value as ElementalContent;
+        return value != null;
+    }
+
+    /// <summary>
+    /// Calls the function parameter corresponding to the variant the instance was constructed with.
+    ///
+    /// <para>Use the <c>TryPick</c> method(s) if you don't need to handle every variant, or <see cref="Match"/>
+    /// if you need your function parameters to return something.</para>
+    ///
+    /// <exception cref="CourierInvalidDataException">
+    /// Thrown when the instance was constructed with an unknown variant (e.g. deserialized from raw data
+    /// that doesn't match any variant's expected shape).
+    /// </exception>
+    ///
+    /// <example>
+    /// <code>
+    /// instance.Switch(
+    ///     (ElementalContentSugar value) =&gt; {...},
+    ///     (ElementalContent value) =&gt; {...}
+    /// );
+    /// </code>
+    /// </example>
+    /// </summary>
+    public void Switch(
+        System::Action<ElementalContentSugar> elementalContentSugar,
+        System::Action<ElementalContent> elemental
+    )
+    {
+        switch (this.Value)
+        {
+            case ElementalContentSugar value:
+                elementalContentSugar(value);
+                break;
+            case ElementalContent value:
+                elemental(value);
+                break;
+            default:
+                throw new CourierInvalidDataException("Data did not match any variant of Content");
+        }
+    }
+
+    /// <summary>
+    /// Calls the function parameter corresponding to the variant the instance was constructed with and
+    /// returns its result.
+    ///
+    /// <para>Use the <c>TryPick</c> method(s) if you don't need to handle every variant, or <see cref="Switch"/>
+    /// if you don't need your function parameters to return a value.</para>
+    ///
+    /// <exception cref="CourierInvalidDataException">
+    /// Thrown when the instance was constructed with an unknown variant (e.g. deserialized from raw data
+    /// that doesn't match any variant's expected shape).
+    /// </exception>
+    ///
+    /// <example>
+    /// <code>
+    /// var result = instance.Match(
+    ///     (ElementalContentSugar value) =&gt; {...},
+    ///     (ElementalContent value) =&gt; {...}
+    /// );
+    /// </code>
+    /// </example>
+    /// </summary>
+    public T Match<T>(
+        System::Func<ElementalContentSugar, T> elementalContentSugar,
+        System::Func<ElementalContent, T> elemental
+    )
+    {
+        return this.Value switch
+        {
+            ElementalContentSugar value => elementalContentSugar(value),
+            ElementalContent value => elemental(value),
+            _ => throw new CourierInvalidDataException("Data did not match any variant of Content"),
+        };
+    }
+
+    public static implicit operator Content(ElementalContentSugar value) => new(value);
+
+    public static implicit operator Content(ElementalContent value) => new(value);
+
+    /// <summary>
+    /// Validates that the instance was constructed with a known variant and that this variant is valid
+    /// (based on its own <c>Validate</c> method).
+    ///
+    /// <para>This is useful for instances constructed from raw JSON data (e.g. deserialized from an API response).</para>
+    ///
+    /// <exception cref="CourierInvalidDataException">
+    /// Thrown when the instance does not pass validation.
+    /// </exception>
+    /// </summary>
+    public override void Validate()
+    {
+        if (this.Value == null)
+        {
+            throw new CourierInvalidDataException("Data did not match any variant of Content");
+        }
+        this.Switch(
+            (elementalContentSugar) => elementalContentSugar.Validate(),
+            (elemental) => elemental.Validate()
+        );
+    }
+
+    public virtual bool Equals(Content? other) =>
+        other != null
+        && this.VariantIndex() == other.VariantIndex()
+        && JsonElement.DeepEquals(this.Json, other.Json);
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+
+    public override string ToString() =>
+        JsonSerializer.Serialize(
+            FriendlyJsonPrinter.PrintValue(this.Json),
+            ModelBase.ToStringSerializerOptions
+        );
+
+    int VariantIndex()
+    {
+        return this.Value switch
+        {
+            ElementalContentSugar _ => 0,
+            ElementalContent _ => 1,
+            _ => -1,
+        };
+    }
+}
+
+sealed class ContentConverter : JsonConverter<Content?>
+{
+    public override Content? Read(
+        ref Utf8JsonReader reader,
+        System::Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        var element = JsonSerializer.Deserialize<JsonElement>(ref reader, options);
+        try
+        {
+            var deserialized = JsonSerializer.Deserialize<ElementalContentSugar>(element, options);
+            if (deserialized != null)
+            {
+                deserialized.Validate();
+                return new(deserialized, element);
+            }
+        }
+        catch (System::Exception e) when (e is JsonException || e is CourierInvalidDataException)
+        {
+            // ignore
+        }
+
+        try
+        {
+            var deserialized = JsonSerializer.Deserialize<ElementalContent>(element, options);
+            if (deserialized != null)
+            {
+                deserialized.Validate();
+                return new(deserialized, element);
+            }
+        }
+        catch (System::Exception e) when (e is JsonException || e is CourierInvalidDataException)
+        {
+            // ignore
+        }
+
+        return new(element);
+    }
+
+    public override void Write(Utf8JsonWriter writer, Content? value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value?.Json, options);
+    }
+}

--- a/src/TryCourier/Models/Bulk/InboundBulkMessageUser.cs
+++ b/src/TryCourier/Models/Bulk/InboundBulkMessageUser.cs
@@ -1,0 +1,139 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+
+namespace TryCourier.Models.Bulk;
+
+[JsonConverter(typeof(JsonModelConverter<InboundBulkMessageUser, InboundBulkMessageUserFromRaw>))]
+public sealed record class InboundBulkMessageUser : JsonModel
+{
+    /// <summary>
+    /// User-specific data that will be merged with message.data
+    /// </summary>
+    public JsonElement? Data
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableStruct<JsonElement>("data");
+        }
+        init
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this._rawData.Set("data", value);
+        }
+    }
+
+    public RecipientPreferences? Preferences
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<RecipientPreferences>("preferences");
+        }
+        init { this._rawData.Set("preferences", value); }
+    }
+
+    /// <summary>
+    /// User profile information. For email-based bulk jobs, `profile.email` is required
+    ///  for provider routing to determine if the message can be delivered. The email
+    ///  address should be provided here rather than in `to.email`.
+    /// </summary>
+    public IReadOnlyDictionary<string, JsonElement>? Profile
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<FrozenDictionary<string, JsonElement>>("profile");
+        }
+        init
+        {
+            this._rawData.Set<FrozenDictionary<string, JsonElement>?>(
+                "profile",
+                value == null ? null : FrozenDictionary.ToFrozenDictionary(value)
+            );
+        }
+    }
+
+    /// <summary>
+    /// User ID (legacy field, use profile or to.user_id instead)
+    /// </summary>
+    public string? Recipient
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<string>("recipient");
+        }
+        init { this._rawData.Set("recipient", value); }
+    }
+
+    /// <summary>
+    /// Optional recipient information. Note: For email provider routing, use  `profile.email`
+    /// instead of `to.email`. The `to` field is primarily used  for recipient identification
+    /// and data merging.
+    /// </summary>
+    public UserRecipient? To
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<UserRecipient>("to");
+        }
+        init { this._rawData.Set("to", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        _ = this.Data;
+        this.Preferences?.Validate();
+        _ = this.Profile;
+        _ = this.Recipient;
+        this.To?.Validate();
+    }
+
+    public InboundBulkMessageUser() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public InboundBulkMessageUser(InboundBulkMessageUser inboundBulkMessageUser)
+        : base(inboundBulkMessageUser) { }
+#pragma warning restore CS8618
+
+    public InboundBulkMessageUser(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    InboundBulkMessageUser(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="InboundBulkMessageUserFromRaw.FromRawUnchecked"/>
+    public static InboundBulkMessageUser FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    )
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+}
+
+class InboundBulkMessageUserFromRaw : IFromRawJson<InboundBulkMessageUser>
+{
+    /// <inheritdoc/>
+    public InboundBulkMessageUser FromRawUnchecked(
+        IReadOnlyDictionary<string, JsonElement> rawData
+    ) => InboundBulkMessageUser.FromRawUnchecked(rawData);
+}

--- a/src/TryCourier/Models/Send/SendMessageParams.cs
+++ b/src/TryCourier/Models/Send/SendMessageParams.cs
@@ -14,7 +14,8 @@ namespace TryCourier.Models.Send;
 
 /// <summary>
 /// Sends a message to one or more recipients and returns a requestId. Courier routes
-/// it to email, SMS, push, chat, or in-app based on your rules.
+/// it to email, SMS, push, chat, or in-app based on your rules. Use the returned
+/// requestId to look up delivery status via the Messages API.
 ///
 /// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
 /// breaking changes in non-major versions. We may add new methods in the future that

--- a/src/TryCourier/Services/BulkService.cs
+++ b/src/TryCourier/Services/BulkService.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TryCourier.Core;
+using TryCourier.Exceptions;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Services;
+
+/// <inheritdoc/>
+public sealed class BulkService : IBulkService
+{
+    readonly Lazy<IBulkServiceWithRawResponse> _withRawResponse;
+
+    /// <inheritdoc/>
+    public IBulkServiceWithRawResponse WithRawResponse
+    {
+        get { return _withRawResponse.Value; }
+    }
+
+    readonly ICourierClient _client;
+
+    /// <inheritdoc/>
+    public IBulkService WithOptions(Func<ClientOptions, ClientOptions> modifier)
+    {
+        return new BulkService(this._client.WithOptions(modifier));
+    }
+
+    public BulkService(ICourierClient client)
+    {
+        _client = client;
+
+        _withRawResponse = new(() => new BulkServiceWithRawResponse(client.WithRawResponse));
+    }
+
+    /// <inheritdoc/>
+    public Task AddUsers(
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return this.WithRawResponse.AddUsers(parameters, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task AddUsers(
+        string jobID,
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await this.AddUsers(parameters with { JobID = jobID }, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<BulkCreateJobResponse> CreateJob(
+        BulkCreateJobParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var response = await this
+            .WithRawResponse.CreateJob(parameters, cancellationToken)
+            .ConfigureAwait(false);
+        return await response.Deserialize(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<BulkListUsersResponse> ListUsers(
+        BulkListUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var response = await this
+            .WithRawResponse.ListUsers(parameters, cancellationToken)
+            .ConfigureAwait(false);
+        return await response.Deserialize(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<BulkListUsersResponse> ListUsers(
+        string jobID,
+        BulkListUsersParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        return this.ListUsers(parameters with { JobID = jobID }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<BulkRetrieveJobResponse> RetrieveJob(
+        BulkRetrieveJobParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        using var response = await this
+            .WithRawResponse.RetrieveJob(parameters, cancellationToken)
+            .ConfigureAwait(false);
+        return await response.Deserialize(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<BulkRetrieveJobResponse> RetrieveJob(
+        string jobID,
+        BulkRetrieveJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        return this.RetrieveJob(parameters with { JobID = jobID }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task RunJob(BulkRunJobParams parameters, CancellationToken cancellationToken = default)
+    {
+        return this.WithRawResponse.RunJob(parameters, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task RunJob(
+        string jobID,
+        BulkRunJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        await this.RunJob(parameters with { JobID = jobID }, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}
+
+/// <inheritdoc/>
+public sealed class BulkServiceWithRawResponse : IBulkServiceWithRawResponse
+{
+    readonly ICourierClientWithRawResponse _client;
+
+    /// <inheritdoc/>
+    public IBulkServiceWithRawResponse WithOptions(Func<ClientOptions, ClientOptions> modifier)
+    {
+        return new BulkServiceWithRawResponse(this._client.WithOptions(modifier));
+    }
+
+    public BulkServiceWithRawResponse(ICourierClientWithRawResponse client)
+    {
+        _client = client;
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse> AddUsers(
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (parameters.JobID == null)
+        {
+            throw new CourierInvalidDataException("'parameters.JobID' cannot be null");
+        }
+
+        HttpRequest<BulkAddUsersParams> request = new()
+        {
+            Method = HttpMethod.Post,
+            Params = parameters,
+        };
+        return this._client.Execute(request, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse> AddUsers(
+        string jobID,
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return this.AddUsers(parameters with { JobID = jobID }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponse<BulkCreateJobResponse>> CreateJob(
+        BulkCreateJobParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        HttpRequest<BulkCreateJobParams> request = new()
+        {
+            Method = HttpMethod.Post,
+            Params = parameters,
+        };
+        var response = await this._client.Execute(request, cancellationToken).ConfigureAwait(false);
+        return new(
+            response,
+            async (token) =>
+            {
+                var deserializedResponse = await response
+                    .Deserialize<BulkCreateJobResponse>(token)
+                    .ConfigureAwait(false);
+                if (this._client.ResponseValidation)
+                {
+                    deserializedResponse.Validate();
+                }
+                return deserializedResponse;
+            }
+        );
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponse<BulkListUsersResponse>> ListUsers(
+        BulkListUsersParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (parameters.JobID == null)
+        {
+            throw new CourierInvalidDataException("'parameters.JobID' cannot be null");
+        }
+
+        HttpRequest<BulkListUsersParams> request = new()
+        {
+            Method = HttpMethod.Get,
+            Params = parameters,
+        };
+        var response = await this._client.Execute(request, cancellationToken).ConfigureAwait(false);
+        return new(
+            response,
+            async (token) =>
+            {
+                var deserializedResponse = await response
+                    .Deserialize<BulkListUsersResponse>(token)
+                    .ConfigureAwait(false);
+                if (this._client.ResponseValidation)
+                {
+                    deserializedResponse.Validate();
+                }
+                return deserializedResponse;
+            }
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse<BulkListUsersResponse>> ListUsers(
+        string jobID,
+        BulkListUsersParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        return this.ListUsers(parameters with { JobID = jobID }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponse<BulkRetrieveJobResponse>> RetrieveJob(
+        BulkRetrieveJobParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (parameters.JobID == null)
+        {
+            throw new CourierInvalidDataException("'parameters.JobID' cannot be null");
+        }
+
+        HttpRequest<BulkRetrieveJobParams> request = new()
+        {
+            Method = HttpMethod.Get,
+            Params = parameters,
+        };
+        var response = await this._client.Execute(request, cancellationToken).ConfigureAwait(false);
+        return new(
+            response,
+            async (token) =>
+            {
+                var deserializedResponse = await response
+                    .Deserialize<BulkRetrieveJobResponse>(token)
+                    .ConfigureAwait(false);
+                if (this._client.ResponseValidation)
+                {
+                    deserializedResponse.Validate();
+                }
+                return deserializedResponse;
+            }
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse<BulkRetrieveJobResponse>> RetrieveJob(
+        string jobID,
+        BulkRetrieveJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        return this.RetrieveJob(parameters with { JobID = jobID }, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse> RunJob(
+        BulkRunJobParams parameters,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (parameters.JobID == null)
+        {
+            throw new CourierInvalidDataException("'parameters.JobID' cannot be null");
+        }
+
+        HttpRequest<BulkRunJobParams> request = new()
+        {
+            Method = HttpMethod.Post,
+            Params = parameters,
+        };
+        return this._client.Execute(request, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<HttpResponse> RunJob(
+        string jobID,
+        BulkRunJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        parameters ??= new();
+
+        return this.RunJob(parameters with { JobID = jobID }, cancellationToken);
+    }
+}

--- a/src/TryCourier/Services/IBulkService.cs
+++ b/src/TryCourier/Services/IBulkService.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TryCourier.Core;
+using TryCourier.Models.Bulk;
+
+namespace TryCourier.Services;
+
+/// <summary>
+/// NOTE: Do not inherit from this type outside the SDK unless you're okay with breaking
+/// changes in non-major versions. We may add new methods in the future that cause
+/// existing derived classes to break.
+/// </summary>
+public interface IBulkService
+{
+    /// <summary>
+    /// Returns a view of this service that provides access to raw HTTP responses
+    /// for each method.
+    /// </summary>
+    IBulkServiceWithRawResponse WithRawResponse { get; }
+
+    /// <summary>
+    /// Returns a view of this service with the given option modifications applied.
+    ///
+    /// <para>The original service is not modified.</para>
+    /// </summary>
+    IBulkService WithOptions(Func<ClientOptions, ClientOptions> modifier);
+
+    /// <summary>
+    /// Ingest user data into a Bulk Job.
+    ///
+    /// <para>**Important**: For email-based bulk jobs, each user must include
+    /// `profile.email`  for provider routing to work correctly. The `to.email` field is not
+    /// sufficient  for email provider routing. </para>
+    /// </summary>
+    Task AddUsers(BulkAddUsersParams parameters, CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="AddUsers(BulkAddUsersParams, CancellationToken)"/>
+    Task AddUsers(
+        string jobID,
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Creates a new bulk job for sending messages to multiple recipients.
+    ///
+    /// <para>**Required**: `message.event` (event ID or notification ID)</para>
+    ///
+    /// <para>**Optional (V2 format)**: `message.template` (notification ID) or
+    /// `message.content` (Elemental content)  can be provided to override the notification
+    /// associated with the event. </para>
+    /// </summary>
+    Task<BulkCreateJobResponse> CreateJob(
+        BulkCreateJobParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Get Bulk Job Users
+    /// </summary>
+    Task<BulkListUsersResponse> ListUsers(
+        BulkListUsersParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="ListUsers(BulkListUsersParams, CancellationToken)"/>
+    Task<BulkListUsersResponse> ListUsers(
+        string jobID,
+        BulkListUsersParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Get a bulk job
+    /// </summary>
+    Task<BulkRetrieveJobResponse> RetrieveJob(
+        BulkRetrieveJobParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="RetrieveJob(BulkRetrieveJobParams, CancellationToken)"/>
+    Task<BulkRetrieveJobResponse> RetrieveJob(
+        string jobID,
+        BulkRetrieveJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Run a bulk job
+    /// </summary>
+    Task RunJob(BulkRunJobParams parameters, CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="RunJob(BulkRunJobParams, CancellationToken)"/>
+    Task RunJob(
+        string jobID,
+        BulkRunJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>
+/// A view of <see cref="IBulkService"/> that provides access to raw
+/// HTTP responses for each method.
+/// </summary>
+public interface IBulkServiceWithRawResponse
+{
+    /// <summary>
+    /// Returns a view of this service with the given option modifications applied.
+    ///
+    /// <para>The original service is not modified.</para>
+    /// </summary>
+    IBulkServiceWithRawResponse WithOptions(Func<ClientOptions, ClientOptions> modifier);
+
+    /// <summary>
+    /// Returns a raw HTTP response for <c>post /bulk/{job_id}</c>, but is otherwise the
+    /// same as <see cref="IBulkService.AddUsers(BulkAddUsersParams, CancellationToken)"/>.
+    /// </summary>
+    Task<HttpResponse> AddUsers(
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="AddUsers(BulkAddUsersParams, CancellationToken)"/>
+    Task<HttpResponse> AddUsers(
+        string jobID,
+        BulkAddUsersParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Returns a raw HTTP response for <c>post /bulk</c>, but is otherwise the
+    /// same as <see cref="IBulkService.CreateJob(BulkCreateJobParams, CancellationToken)"/>.
+    /// </summary>
+    Task<HttpResponse<BulkCreateJobResponse>> CreateJob(
+        BulkCreateJobParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Returns a raw HTTP response for <c>get /bulk/{job_id}/users</c>, but is otherwise the
+    /// same as <see cref="IBulkService.ListUsers(BulkListUsersParams, CancellationToken)"/>.
+    /// </summary>
+    Task<HttpResponse<BulkListUsersResponse>> ListUsers(
+        BulkListUsersParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="ListUsers(BulkListUsersParams, CancellationToken)"/>
+    Task<HttpResponse<BulkListUsersResponse>> ListUsers(
+        string jobID,
+        BulkListUsersParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Returns a raw HTTP response for <c>get /bulk/{job_id}</c>, but is otherwise the
+    /// same as <see cref="IBulkService.RetrieveJob(BulkRetrieveJobParams, CancellationToken)"/>.
+    /// </summary>
+    Task<HttpResponse<BulkRetrieveJobResponse>> RetrieveJob(
+        BulkRetrieveJobParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="RetrieveJob(BulkRetrieveJobParams, CancellationToken)"/>
+    Task<HttpResponse<BulkRetrieveJobResponse>> RetrieveJob(
+        string jobID,
+        BulkRetrieveJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Returns a raw HTTP response for <c>post /bulk/{job_id}/run</c>, but is otherwise the
+    /// same as <see cref="IBulkService.RunJob(BulkRunJobParams, CancellationToken)"/>.
+    /// </summary>
+    Task<HttpResponse> RunJob(
+        BulkRunJobParams parameters,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <inheritdoc cref="RunJob(BulkRunJobParams, CancellationToken)"/>
+    Task<HttpResponse> RunJob(
+        string jobID,
+        BulkRunJobParams? parameters = null,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/TryCourier/Services/ISendService.cs
+++ b/src/TryCourier/Services/ISendService.cs
@@ -31,7 +31,8 @@ public interface ISendService
 
     /// <summary>
     /// Sends a message to one or more recipients and returns a requestId. Courier
-    /// routes it to email, SMS, push, chat, or in-app based on your rules.
+    /// routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+    /// returned requestId to look up delivery status via the Messages API.
     /// </summary>
     Task<SendMessageResponse> Message(
         SendMessageParams parameters,

--- a/src/TryCourier/TryCourier.csproj
+++ b/src/TryCourier/TryCourier.csproj
@@ -9,12 +9,12 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="TryCourier.Tests"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.9"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <InternalsVisibleTo Include="TryCourier.Tests" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

30 files changed, 7734 insertions(+), 14 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                                      |    5 +-
 src/TryCourier.Tests/Models/Bulk/BulkAddUsersParamsTest.cs      |  408 ++++++
 src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs     |  145 ++
 src/TryCourier.Tests/Models/Bulk/BulkCreateJobResponseTest.cs   |   67 +
 src/TryCourier.Tests/Models/Bulk/BulkListUsersParamsTest.cs     |   67 +
 src/TryCourier.Tests/Models/Bulk/BulkListUsersResponseTest.cs   | 2114 +++++++++++++++++++++++++++
 src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobParamsTest.cs   |   37 +
 src/TryCourier.Tests/Models/Bulk/BulkRetrieveJobResponseTest.cs |  639 ++++++++
 src/TryCourier.Tests/Models/Bulk/BulkRunJobParamsTest.cs        |   37 +
 src/TryCourier.Tests/Models/Bulk/InboundBulkMessageTest.cs      |  444 ++++++
 src/TryCourier.Tests/Models/Bulk/InboundBulkMessageUserTest.cs  | 1071 ++++++++++++++
 src/TryCourier.Tests/Services/BulkServiceTest.cs                |  182 +++
 src/TryCourier/Core/ModelBase.cs                                |    9 +-
 src/TryCourier/CourierClient.cs                                 |   14 +
 src/TryCourier/ICourierClient.cs                                |    4 +
 src/TryCourier/Models/Bulk/BulkAddUsersParams.cs                |  170 +++
 src/TryCourier/Models/Bulk/BulkCreateJobParams.cs               |  156 ++
 src/TryCourier/Models/Bulk/BulkCreateJobResponse.cs             |   72 +
 src/TryCourier/Models/Bulk/BulkListUsersParams.cs               |  135 ++
 src/TryCourier/Models/Bulk/BulkListUsersResponse.cs             |  383 +++++
 src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs             |  121 ++
 src/TryCourier/Models/Bulk/BulkRetrieveJobResponse.cs           |  227 +++
 src/TryCourier/Models/Bulk/BulkRunJobParams.cs                  |  121 ++
 src/TryCourier/Models/Bulk/InboundBulkMessage.cs                |  448 ++++++
 src/TryCourier/Models/Bulk/InboundBulkMessageUser.cs            |  139 ++
 src/TryCourier/Models/Send/SendMessageParams.cs                 |    3 +-
 src/TryCourier/Services/BulkService.cs                          |  330 +++++
 src/TryCourier/Services/IBulkService.cs                         |  187 +++
 src/TryCourier/Services/ISendService.cs                         |    3 +-
 src/TryCourier/TryCourier.csproj                                |   10 +-
 30 files changed, 7734 insertions(+), 14 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
