### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/src/TryCourier.Tests/Models/Audiences/AudienceUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Audiences/AudienceUpdateParamsTest.cs
@@ -15,42 +15,42 @@ public class AudienceUpdateParamsTest : TestBase
         var parameters = new AudienceUpdateParams
         {
             AudienceID = "audience_id",
-            Description = "description",
+            Description = "Users located in the US",
             Filter = new()
             {
                 Filters =
                 [
                     new()
                     {
-                        Operator = "operator",
+                        Operator = "EQ",
                         Filters = [],
-                        Path = "path",
-                        Value = "value",
+                        Path = "profile.location",
+                        Value = "US",
                     },
                 ],
                 Operator = Models::AudienceFilterConfigOperator.And,
             },
-            Name = "name",
+            Name = "Engaged US Users",
             Operator = Operator.And,
         };
 
         string expectedAudienceID = "audience_id";
-        string expectedDescription = "description";
+        string expectedDescription = "Users located in the US";
         Models::AudienceFilterConfig expectedFilter = new()
         {
             Filters =
             [
                 new()
                 {
-                    Operator = "operator",
+                    Operator = "EQ",
                     Filters = [],
-                    Path = "path",
-                    Value = "value",
+                    Path = "profile.location",
+                    Value = "US",
                 },
             ],
             Operator = Models::AudienceFilterConfigOperator.And,
         };
-        string expectedName = "name";
+        string expectedName = "Engaged US Users";
         ApiEnum<string, Operator> expectedOperator = Operator.And;
 
         Assert.Equal(expectedAudienceID, parameters.AudienceID);
@@ -116,22 +116,22 @@ public class AudienceUpdateParamsTest : TestBase
         var parameters = new AudienceUpdateParams
         {
             AudienceID = "audience_id",
-            Description = "description",
+            Description = "Users located in the US",
             Filter = new()
             {
                 Filters =
                 [
                     new()
                     {
-                        Operator = "operator",
+                        Operator = "EQ",
                         Filters = [],
-                        Path = "path",
-                        Value = "value",
+                        Path = "profile.location",
+                        Value = "US",
                     },
                 ],
                 Operator = Models::AudienceFilterConfigOperator.And,
             },
-            Name = "name",
+            Name = "Engaged US Users",
             Operator = Operator.And,
         };
 

--- a/src/TryCourier.Tests/Models/Automations/Invoke/InvokeInvokeByTemplateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Automations/Invoke/InvokeInvokeByTemplateParamsTest.cs
@@ -14,15 +14,15 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             Brand = "brand",
             Data = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "orderId", JsonSerializer.SerializeToElement("bar") },
             },
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
             },
             Template = "template",
             IdempotencyKey = "order-ORD-456-user-123",
@@ -30,15 +30,15 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         };
 
         string expectedTemplateID = "templateId";
-        string expectedRecipient = "recipient";
+        string expectedRecipient = "user_abc";
         string expectedBrand = "brand";
         Dictionary<string, JsonElement> expectedData = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "orderId", JsonSerializer.SerializeToElement("bar") },
         };
         Dictionary<string, JsonElement> expectedProfile = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "email", JsonSerializer.SerializeToElement("bar") },
         };
         string expectedTemplate = "template";
         string expectedIdempotencyKey = "order-ORD-456-user-123";
@@ -74,15 +74,15 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             Brand = "brand",
             Data = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "orderId", JsonSerializer.SerializeToElement("bar") },
             },
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
             },
             Template = "template",
         };
@@ -99,15 +99,15 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             Brand = "brand",
             Data = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "orderId", JsonSerializer.SerializeToElement("bar") },
             },
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
             },
             Template = "template",
 
@@ -128,7 +128,7 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };
@@ -149,7 +149,7 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
 
@@ -175,7 +175,7 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         InvokeInvokeByTemplateParams parameters = new()
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
         };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
@@ -195,7 +195,7 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         InvokeInvokeByTemplateParams parameters = new()
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };
@@ -215,15 +215,15 @@ public class InvokeInvokeByTemplateParamsTest : TestBase
         var parameters = new InvokeInvokeByTemplateParams
         {
             TemplateID = "templateId",
-            Recipient = "recipient",
+            Recipient = "user_abc",
             Brand = "brand",
             Data = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "orderId", JsonSerializer.SerializeToElement("bar") },
             },
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
             },
             Template = "template",
             IdempotencyKey = "order-ORD-456-user-123",

--- a/src/TryCourier.Tests/Models/Brands/BrandUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Brands/BrandUpdateParamsTest.cs
@@ -11,10 +11,10 @@ public class BrandUpdateParamsTest : TestBase
         var parameters = new BrandUpdateParams
         {
             BrandID = "brand_id",
-            Name = "name",
+            Name = "My Brand",
             Settings = new()
             {
-                Colors = new() { Primary = "primary", Secondary = "secondary" },
+                Colors = new() { Primary = "#9D3789", Secondary = "#FFFFFF" },
                 Email = new()
                 {
                     Footer = new() { Content = "content", InheritDefault = true },
@@ -63,10 +63,10 @@ public class BrandUpdateParamsTest : TestBase
         };
 
         string expectedBrandID = "brand_id";
-        string expectedName = "name";
+        string expectedName = "My Brand";
         BrandSettings expectedSettings = new()
         {
-            Colors = new() { Primary = "primary", Secondary = "secondary" },
+            Colors = new() { Primary = "#9D3789", Secondary = "#FFFFFF" },
             Email = new()
             {
                 Footer = new() { Content = "content", InheritDefault = true },
@@ -125,7 +125,7 @@ public class BrandUpdateParamsTest : TestBase
     [Fact]
     public void OptionalNullableParamsUnsetAreNotSet_Works()
     {
-        var parameters = new BrandUpdateParams { BrandID = "brand_id", Name = "name" };
+        var parameters = new BrandUpdateParams { BrandID = "brand_id", Name = "My Brand" };
 
         Assert.Null(parameters.Settings);
         Assert.False(parameters.RawBodyData.ContainsKey("settings"));
@@ -139,7 +139,7 @@ public class BrandUpdateParamsTest : TestBase
         var parameters = new BrandUpdateParams
         {
             BrandID = "brand_id",
-            Name = "name",
+            Name = "My Brand",
 
             Settings = null,
             Snippets = null,
@@ -154,7 +154,7 @@ public class BrandUpdateParamsTest : TestBase
     [Fact]
     public void Url_Works()
     {
-        BrandUpdateParams parameters = new() { BrandID = "brand_id", Name = "name" };
+        BrandUpdateParams parameters = new() { BrandID = "brand_id", Name = "My Brand" };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
 
@@ -167,10 +167,10 @@ public class BrandUpdateParamsTest : TestBase
         var parameters = new BrandUpdateParams
         {
             BrandID = "brand_id",
-            Name = "name",
+            Name = "My Brand",
             Settings = new()
             {
-                Colors = new() { Primary = "primary", Secondary = "secondary" },
+                Colors = new() { Primary = "#9D3789", Secondary = "#FFFFFF" },
                 Email = new()
                 {
                     Footer = new() { Content = "content", InheritDefault = true },

--- a/src/TryCourier.Tests/Models/Bulk/BulkAddUsersParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkAddUsersParamsTest.cs
@@ -18,7 +18,13 @@ public class BulkAddUsersParamsTest : TestBase
             [
                 new()
                 {
-                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Data = JsonSerializer.Deserialize<JsonElement>(
+                        """
+                        {
+                          "name": "Jane"
+                        }
+                        """
+                    ),
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -48,9 +54,9 @@ public class BulkAddUsersParamsTest : TestBase
                     },
                     Profile = new Dictionary<string, JsonElement>()
                     {
-                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                        { "email", JsonSerializer.SerializeToElement("bar") },
                     },
-                    Recipient = "recipient",
+                    Recipient = "user_abc",
                     To = new()
                     {
                         AccountID = "account_id",
@@ -111,7 +117,13 @@ public class BulkAddUsersParamsTest : TestBase
         [
             new()
             {
-                Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                Data = JsonSerializer.Deserialize<JsonElement>(
+                    """
+                    {
+                      "name": "Jane"
+                    }
+                    """
+                ),
                 Preferences = new()
                 {
                     Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -141,9 +153,9 @@ public class BulkAddUsersParamsTest : TestBase
                 },
                 Profile = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "email", JsonSerializer.SerializeToElement("bar") },
                 },
-                Recipient = "recipient",
+                Recipient = "user_abc",
                 To = new()
                 {
                     AccountID = "account_id",
@@ -210,7 +222,13 @@ public class BulkAddUsersParamsTest : TestBase
             [
                 new()
                 {
-                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Data = JsonSerializer.Deserialize<JsonElement>(
+                        """
+                        {
+                          "name": "Jane"
+                        }
+                        """
+                    ),
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -240,9 +258,9 @@ public class BulkAddUsersParamsTest : TestBase
                     },
                     Profile = new Dictionary<string, JsonElement>()
                     {
-                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                        { "email", JsonSerializer.SerializeToElement("bar") },
                     },
-                    Recipient = "recipient",
+                    Recipient = "user_abc",
                     To = new()
                     {
                         AccountID = "account_id",
@@ -313,7 +331,13 @@ public class BulkAddUsersParamsTest : TestBase
             [
                 new()
                 {
-                    Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                    Data = JsonSerializer.Deserialize<JsonElement>(
+                        """
+                        {
+                          "name": "Jane"
+                        }
+                        """
+                    ),
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -343,9 +367,9 @@ public class BulkAddUsersParamsTest : TestBase
                     },
                     Profile = new Dictionary<string, JsonElement>()
                     {
-                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                        { "email", JsonSerializer.SerializeToElement("bar") },
                     },
-                    Recipient = "recipient",
+                    Recipient = "user_abc",
                     To = new()
                     {
                         AccountID = "account_id",

--- a/src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs
@@ -15,12 +15,12 @@ public class BulkCreateJobParamsTest : TestBase
         {
             Message = new()
             {
-                Event = "event",
-                Brand = "brand",
+                Event = "welcome-series",
+                Brand = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                 Content = new ElementalContentSugar() { Body = "body", Title = "title" },
                 Data = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "campaign", JsonSerializer.SerializeToElement("bar") },
                 },
                 Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
                 {
@@ -42,12 +42,12 @@ public class BulkCreateJobParamsTest : TestBase
 
         InboundBulkMessage expectedMessage = new()
         {
-            Event = "event",
-            Brand = "brand",
+            Event = "welcome-series",
+            Brand = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
             Content = new ElementalContentSugar() { Body = "body", Title = "title" },
             Data = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "campaign", JsonSerializer.SerializeToElement("bar") },
             },
             Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
             {
@@ -76,12 +76,12 @@ public class BulkCreateJobParamsTest : TestBase
         {
             Message = new()
             {
-                Event = "event",
-                Brand = "brand",
+                Event = "welcome-series",
+                Brand = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                 Content = new ElementalContentSugar() { Body = "body", Title = "title" },
                 Data = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "campaign", JsonSerializer.SerializeToElement("bar") },
                 },
                 Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
                 {
@@ -113,12 +113,12 @@ public class BulkCreateJobParamsTest : TestBase
         {
             Message = new()
             {
-                Event = "event",
-                Brand = "brand",
+                Event = "welcome-series",
+                Brand = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                 Content = new ElementalContentSugar() { Body = "body", Title = "title" },
                 Data = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "campaign", JsonSerializer.SerializeToElement("bar") },
                 },
                 Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
                 {

--- a/src/TryCourier.Tests/Models/Lists/ListUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Lists/ListUpdateParamsTest.cs
@@ -13,7 +13,7 @@ public class ListUpdateParamsTest : TestBase
         var parameters = new ListUpdateParams
         {
             ListID = "list_id",
-            Name = "name",
+            Name = "Product Updates",
             Preferences = new()
             {
                 Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -44,7 +44,7 @@ public class ListUpdateParamsTest : TestBase
         };
 
         string expectedListID = "list_id";
-        string expectedName = "name";
+        string expectedName = "Product Updates";
         RecipientPreferences expectedPreferences = new()
         {
             Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -81,7 +81,7 @@ public class ListUpdateParamsTest : TestBase
     [Fact]
     public void OptionalNullableParamsUnsetAreNotSet_Works()
     {
-        var parameters = new ListUpdateParams { ListID = "list_id", Name = "name" };
+        var parameters = new ListUpdateParams { ListID = "list_id", Name = "Product Updates" };
 
         Assert.Null(parameters.Preferences);
         Assert.False(parameters.RawBodyData.ContainsKey("preferences"));
@@ -93,7 +93,7 @@ public class ListUpdateParamsTest : TestBase
         var parameters = new ListUpdateParams
         {
             ListID = "list_id",
-            Name = "name",
+            Name = "Product Updates",
 
             Preferences = null,
         };
@@ -105,7 +105,7 @@ public class ListUpdateParamsTest : TestBase
     [Fact]
     public void Url_Works()
     {
-        ListUpdateParams parameters = new() { ListID = "list_id", Name = "name" };
+        ListUpdateParams parameters = new() { ListID = "list_id", Name = "Product Updates" };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
 
@@ -118,7 +118,7 @@ public class ListUpdateParamsTest : TestBase
         var parameters = new ListUpdateParams
         {
             ListID = "list_id",
-            Name = "name",
+            Name = "Product Updates",
             Preferences = new()
             {
                 Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionAddParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionAddParamsTest.cs
@@ -19,7 +19,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -58,7 +89,38 @@ public class SubscriptionAddParamsTest : TestBase
         [
             new()
             {
-                RecipientID = "recipientId",
+                RecipientID = "user_abc",
+                Preferences = new()
+                {
+                    Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                    Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                },
+            },
+            new()
+            {
+                RecipientID = "user_def",
                 Preferences = new()
                 {
                     Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -111,7 +173,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -159,7 +252,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -211,7 +335,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -261,7 +416,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -314,7 +500,38 @@ public class SubscriptionAddParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionSubscribeParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionSubscribeParamsTest.cs
@@ -18,7 +18,38 @@ public class SubscriptionSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -55,7 +86,38 @@ public class SubscriptionSubscribeParamsTest : TestBase
         [
             new()
             {
-                RecipientID = "recipientId",
+                RecipientID = "user_abc",
+                Preferences = new()
+                {
+                    Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                    Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                    {
+                        {
+                            "foo",
+                            new()
+                            {
+                                Status = PreferenceStatus.OptedIn,
+                                ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                Rules = [new() { Until = "until", Start = "start" }],
+                            }
+                        },
+                    },
+                },
+            },
+            new()
+            {
+                RecipientID = "user_def",
                 Preferences = new()
                 {
                     Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -104,7 +166,38 @@ public class SubscriptionSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -153,7 +246,38 @@ public class SubscriptionSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    RecipientID = "recipientId",
+                    RecipientID = "user_abc",
+                    Preferences = new()
+                    {
+                        Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                        Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                        {
+                            {
+                                "foo",
+                                new()
+                                {
+                                    Status = PreferenceStatus.OptedIn,
+                                    ChannelPreferences = [new(ChannelClassification.DirectMessage)],
+                                    Rules = [new() { Until = "until", Start = "start" }],
+                                }
+                            },
+                        },
+                    },
+                },
+                new()
+                {
+                    RecipientID = "user_def",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionSubscribeUserParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Lists/Subscriptions/SubscriptionSubscribeUserParamsTest.cs
@@ -31,7 +31,7 @@ public class SubscriptionSubscribeUserParamsTest : TestBase
                 Notifications = new Dictionary<string, NotificationPreferenceDetails>()
                 {
                     {
-                        "foo",
+                        "nt_01kx4h2jdafq8bk9aftxak4b40",
                         new()
                         {
                             Status = PreferenceStatus.OptedIn,
@@ -62,7 +62,7 @@ public class SubscriptionSubscribeUserParamsTest : TestBase
             Notifications = new Dictionary<string, NotificationPreferenceDetails>()
             {
                 {
-                    "foo",
+                    "nt_01kx4h2jdafq8bk9aftxak4b40",
                     new()
                     {
                         Status = PreferenceStatus.OptedIn,
@@ -149,7 +149,7 @@ public class SubscriptionSubscribeUserParamsTest : TestBase
                 Notifications = new Dictionary<string, NotificationPreferenceDetails>()
                 {
                     {
-                        "foo",
+                        "nt_01kx4h2jdafq8bk9aftxak4b40",
                         new()
                         {
                             Status = PreferenceStatus.OptedIn,

--- a/src/TryCourier.Tests/Models/Notifications/Checks/CheckUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Notifications/Checks/CheckUpdateParamsTest.cs
@@ -18,7 +18,7 @@ public class CheckUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    ID = "id",
+                    ID = "abc-123",
                     Status = Notifications::Status.Resolved,
                     Type = Notifications::Type.Custom,
                 },
@@ -31,7 +31,7 @@ public class CheckUpdateParamsTest : TestBase
         [
             new()
             {
-                ID = "id",
+                ID = "abc-123",
                 Status = Notifications::Status.Resolved,
                 Type = Notifications::Type.Custom,
             },
@@ -57,7 +57,7 @@ public class CheckUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    ID = "id",
+                    ID = "abc-123",
                     Status = Notifications::Status.Resolved,
                     Type = Notifications::Type.Custom,
                 },
@@ -85,7 +85,7 @@ public class CheckUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    ID = "id",
+                    ID = "abc-123",
                     Status = Notifications::Status.Resolved,
                     Type = Notifications::Type.Custom,
                 },

--- a/src/TryCourier.Tests/Models/Profiles/Lists/ListSubscribeParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Profiles/Lists/ListSubscribeParamsTest.cs
@@ -19,7 +19,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -58,7 +58,7 @@ public class ListSubscribeParamsTest : TestBase
         [
             new()
             {
-                ListID = "listId",
+                ListID = "example.list.id",
                 Preferences = new()
                 {
                     Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -111,7 +111,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -159,7 +159,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -211,7 +211,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -261,7 +261,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -314,7 +314,7 @@ public class ListSubscribeParamsTest : TestBase
             [
                 new()
                 {
-                    ListID = "listId",
+                    ListID = "example.list.id",
                     Preferences = new()
                     {
                         Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Models/Profiles/ProfileCreateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Profiles/ProfileCreateParamsTest.cs
@@ -16,7 +16,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
@@ -25,7 +26,8 @@ public class ProfileCreateParamsTest : TestBase
         string expectedUserID = "user_id";
         Dictionary<string, JsonElement> expectedProfile = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "email", JsonSerializer.SerializeToElement("bar") },
+            { "phone_number", JsonSerializer.SerializeToElement("bar") },
         };
         string expectedIdempotencyKey = "order-ORD-456-user-123";
         string expectedXIdempotencyExpiration = "1785312000";
@@ -50,7 +52,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
         };
 
@@ -68,7 +71,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
 
             // Null should be interpreted as omitted for these properties
@@ -90,7 +94,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
         };
 
@@ -108,7 +113,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
@@ -131,7 +137,8 @@ public class ProfileCreateParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
             },
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",

--- a/src/TryCourier.Tests/Models/Profiles/ProfileReplaceParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Profiles/ProfileReplaceParamsTest.cs
@@ -15,14 +15,18 @@ public class ProfileReplaceParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
+                { "locale", JsonSerializer.SerializeToElement("bar") },
             },
         };
 
         string expectedUserID = "user_id";
         Dictionary<string, JsonElement> expectedProfile = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "email", JsonSerializer.SerializeToElement("bar") },
+            { "phone_number", JsonSerializer.SerializeToElement("bar") },
+            { "locale", JsonSerializer.SerializeToElement("bar") },
         };
 
         Assert.Equal(expectedUserID, parameters.UserID);
@@ -43,7 +47,9 @@ public class ProfileReplaceParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
+                { "locale", JsonSerializer.SerializeToElement("bar") },
             },
         };
 
@@ -60,7 +66,9 @@ public class ProfileReplaceParamsTest : TestBase
             UserID = "user_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "email", JsonSerializer.SerializeToElement("bar") },
+                { "phone_number", JsonSerializer.SerializeToElement("bar") },
+                { "locale", JsonSerializer.SerializeToElement("bar") },
             },
         };
 

--- a/src/TryCourier.Tests/Models/Profiles/ProfileUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Profiles/ProfileUpdateParamsTest.cs
@@ -18,9 +18,9 @@ public class ProfileUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/email",
+                    Value = "jdoe@example.com",
                 },
             ],
         };
@@ -30,9 +30,9 @@ public class ProfileUpdateParamsTest : TestBase
         [
             new()
             {
-                Op = "op",
-                Path = "path",
-                Value = "value",
+                Op = "replace",
+                Path = "/email",
+                Value = "jdoe@example.com",
             },
         ];
 
@@ -54,9 +54,9 @@ public class ProfileUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/email",
+                    Value = "jdoe@example.com",
                 },
             ],
         };
@@ -76,9 +76,9 @@ public class ProfileUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/email",
+                    Value = "jdoe@example.com",
                 },
             ],
         };

--- a/src/TryCourier.Tests/Models/Providers/ProviderCreateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Providers/ProviderCreateParamsTest.cs
@@ -13,24 +13,24 @@ public class ProviderCreateParamsTest : TestBase
     {
         var parameters = new ProviderCreateParams
         {
-            Provider = "provider",
+            Provider = "sendgrid",
             Alias = "alias",
             Settings = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "api_key", JsonSerializer.SerializeToElement("bar") },
             },
-            Title = "title",
+            Title = "Production SendGrid",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };
 
-        string expectedProvider = "provider";
+        string expectedProvider = "sendgrid";
         string expectedAlias = "alias";
         Dictionary<string, JsonElement> expectedSettings = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "api_key", JsonSerializer.SerializeToElement("bar") },
         };
-        string expectedTitle = "title";
+        string expectedTitle = "Production SendGrid";
         string expectedIdempotencyKey = "order-ORD-456-user-123";
         string expectedXIdempotencyExpiration = "1785312000";
 
@@ -52,7 +52,7 @@ public class ProviderCreateParamsTest : TestBase
     [Fact]
     public void OptionalNonNullableParamsUnsetAreNotSet_Works()
     {
-        var parameters = new ProviderCreateParams { Provider = "provider" };
+        var parameters = new ProviderCreateParams { Provider = "sendgrid" };
 
         Assert.Null(parameters.Alias);
         Assert.False(parameters.RawBodyData.ContainsKey("alias"));
@@ -71,7 +71,7 @@ public class ProviderCreateParamsTest : TestBase
     {
         var parameters = new ProviderCreateParams
         {
-            Provider = "provider",
+            Provider = "sendgrid",
 
             // Null should be interpreted as omitted for these properties
             Alias = null,
@@ -96,7 +96,7 @@ public class ProviderCreateParamsTest : TestBase
     [Fact]
     public void Url_Works()
     {
-        ProviderCreateParams parameters = new() { Provider = "provider" };
+        ProviderCreateParams parameters = new() { Provider = "sendgrid" };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
 
@@ -109,7 +109,7 @@ public class ProviderCreateParamsTest : TestBase
         HttpRequestMessage requestMessage = new();
         ProviderCreateParams parameters = new()
         {
-            Provider = "provider",
+            Provider = "sendgrid",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };
@@ -128,13 +128,13 @@ public class ProviderCreateParamsTest : TestBase
     {
         var parameters = new ProviderCreateParams
         {
-            Provider = "provider",
+            Provider = "sendgrid",
             Alias = "alias",
             Settings = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "api_key", JsonSerializer.SerializeToElement("bar") },
             },
-            Title = "title",
+            Title = "Production SendGrid",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };

--- a/src/TryCourier.Tests/Models/Providers/ProviderUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Providers/ProviderUpdateParamsTest.cs
@@ -13,23 +13,23 @@ public class ProviderUpdateParamsTest : TestBase
         var parameters = new ProviderUpdateParams
         {
             ID = "id",
-            Provider = "provider",
+            Provider = "sendgrid",
             Alias = "alias",
             Settings = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "api_key", JsonSerializer.SerializeToElement("bar") },
             },
-            Title = "title",
+            Title = "Production SendGrid",
         };
 
         string expectedID = "id";
-        string expectedProvider = "provider";
+        string expectedProvider = "sendgrid";
         string expectedAlias = "alias";
         Dictionary<string, JsonElement> expectedSettings = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "api_key", JsonSerializer.SerializeToElement("bar") },
         };
-        string expectedTitle = "title";
+        string expectedTitle = "Production SendGrid";
 
         Assert.Equal(expectedID, parameters.ID);
         Assert.Equal(expectedProvider, parameters.Provider);
@@ -48,7 +48,7 @@ public class ProviderUpdateParamsTest : TestBase
     [Fact]
     public void OptionalNonNullableParamsUnsetAreNotSet_Works()
     {
-        var parameters = new ProviderUpdateParams { ID = "id", Provider = "provider" };
+        var parameters = new ProviderUpdateParams { ID = "id", Provider = "sendgrid" };
 
         Assert.Null(parameters.Alias);
         Assert.False(parameters.RawBodyData.ContainsKey("alias"));
@@ -64,7 +64,7 @@ public class ProviderUpdateParamsTest : TestBase
         var parameters = new ProviderUpdateParams
         {
             ID = "id",
-            Provider = "provider",
+            Provider = "sendgrid",
 
             // Null should be interpreted as omitted for these properties
             Alias = null,
@@ -83,7 +83,7 @@ public class ProviderUpdateParamsTest : TestBase
     [Fact]
     public void Url_Works()
     {
-        ProviderUpdateParams parameters = new() { ID = "id", Provider = "provider" };
+        ProviderUpdateParams parameters = new() { ID = "id", Provider = "sendgrid" };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
 
@@ -96,13 +96,13 @@ public class ProviderUpdateParamsTest : TestBase
         var parameters = new ProviderUpdateParams
         {
             ID = "id",
-            Provider = "provider",
+            Provider = "sendgrid",
             Alias = "alias",
             Settings = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "api_key", JsonSerializer.SerializeToElement("bar") },
             },
-            Title = "title",
+            Title = "Production SendGrid",
         };
 
         ProviderUpdateParams copied = new(parameters);

--- a/src/TryCourier.Tests/Models/Tenants/Templates/TemplatePublishParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Tenants/Templates/TemplatePublishParamsTest.cs
@@ -12,12 +12,12 @@ public class TemplatePublishParamsTest : TestBase
         {
             TenantID = "tenant_id",
             TemplateID = "template_id",
-            Version = "version",
+            Version = "latest",
         };
 
         string expectedTenantID = "tenant_id";
         string expectedTemplateID = "template_id";
-        string expectedVersion = "version";
+        string expectedVersion = "latest";
 
         Assert.Equal(expectedTenantID, parameters.TenantID);
         Assert.Equal(expectedTemplateID, parameters.TemplateID);
@@ -79,7 +79,7 @@ public class TemplatePublishParamsTest : TestBase
         {
             TenantID = "tenant_id",
             TemplateID = "template_id",
-            Version = "version",
+            Version = "latest",
         };
 
         TemplatePublishParams copied = new(parameters);

--- a/src/TryCourier.Tests/Models/Tenants/Templates/TemplateReplaceParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Tenants/Templates/TemplateReplaceParamsTest.cs
@@ -31,7 +31,7 @@ public class TemplateReplaceParamsTest : TestBase
                             Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                         },
                     ],
-                    Version = "version",
+                    Version = "2022-01-01",
                 },
                 Channels = new Dictionary<string, Channel>()
                 {
@@ -88,7 +88,7 @@ public class TemplateReplaceParamsTest : TestBase
                         }
                     },
                 },
-                Routing = new() { Channels = ["string"], Method = Method.All },
+                Routing = new() { Channels = ["email"], Method = Method.Single },
             },
             Published = true,
         };
@@ -110,7 +110,7 @@ public class TemplateReplaceParamsTest : TestBase
                         Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                     },
                 ],
-                Version = "version",
+                Version = "2022-01-01",
             },
             Channels = new Dictionary<string, Channel>()
             {
@@ -167,7 +167,7 @@ public class TemplateReplaceParamsTest : TestBase
                     }
                 },
             },
-            Routing = new() { Channels = ["string"], Method = Method.All },
+            Routing = new() { Channels = ["email"], Method = Method.Single },
         };
         bool expectedPublished = true;
 
@@ -199,7 +199,7 @@ public class TemplateReplaceParamsTest : TestBase
                             Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                         },
                     ],
-                    Version = "version",
+                    Version = "2022-01-01",
                 },
                 Channels = new Dictionary<string, Channel>()
                 {
@@ -256,7 +256,7 @@ public class TemplateReplaceParamsTest : TestBase
                         }
                     },
                 },
-                Routing = new() { Channels = ["string"], Method = Method.All },
+                Routing = new() { Channels = ["email"], Method = Method.Single },
             },
         };
 
@@ -286,7 +286,7 @@ public class TemplateReplaceParamsTest : TestBase
                             Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                         },
                     ],
-                    Version = "version",
+                    Version = "2022-01-01",
                 },
                 Channels = new Dictionary<string, Channel>()
                 {
@@ -343,7 +343,7 @@ public class TemplateReplaceParamsTest : TestBase
                         }
                     },
                 },
-                Routing = new() { Channels = ["string"], Method = Method.All },
+                Routing = new() { Channels = ["email"], Method = Method.Single },
             },
 
             // Null should be interpreted as omitted for these properties
@@ -376,7 +376,7 @@ public class TemplateReplaceParamsTest : TestBase
                             Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                         },
                     ],
-                    Version = "version",
+                    Version = "2022-01-01",
                 },
                 Channels = new Dictionary<string, Channel>()
                 {
@@ -433,7 +433,7 @@ public class TemplateReplaceParamsTest : TestBase
                         }
                     },
                 },
-                Routing = new() { Channels = ["string"], Method = Method.All },
+                Routing = new() { Channels = ["email"], Method = Method.Single },
             },
         };
 
@@ -469,7 +469,7 @@ public class TemplateReplaceParamsTest : TestBase
                             Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                         },
                     ],
-                    Version = "version",
+                    Version = "2022-01-01",
                 },
                 Channels = new Dictionary<string, Channel>()
                 {
@@ -526,7 +526,7 @@ public class TemplateReplaceParamsTest : TestBase
                         }
                     },
                 },
-                Routing = new() { Channels = ["string"], Method = Method.All },
+                Routing = new() { Channels = ["email"], Method = Method.Single },
             },
             Published = true,
         };

--- a/src/TryCourier.Tests/Models/Tenants/TenantUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Tenants/TenantUpdateParamsTest.cs
@@ -14,8 +14,8 @@ public class TenantUpdateParamsTest : TestBase
         var parameters = new TenantUpdateParams
         {
             TenantID = "tenant_id",
-            Name = "name",
-            BrandID = "brand_id",
+            Name = "Acme Corp",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
             DefaultPreferences = new()
             {
                 Items =
@@ -32,7 +32,7 @@ public class TenantUpdateParamsTest : TestBase
             ParentTenantID = "parent_tenant_id",
             Properties = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "plan", JsonSerializer.SerializeToElement("bar") },
             },
             UserProfile = new Dictionary<string, JsonElement>()
             {
@@ -41,8 +41,8 @@ public class TenantUpdateParamsTest : TestBase
         };
 
         string expectedTenantID = "tenant_id";
-        string expectedName = "name";
-        string expectedBrandID = "brand_id";
+        string expectedName = "Acme Corp";
+        string expectedBrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag";
         DefaultPreferences expectedDefaultPreferences = new()
         {
             Items =
@@ -59,7 +59,7 @@ public class TenantUpdateParamsTest : TestBase
         string expectedParentTenantID = "parent_tenant_id";
         Dictionary<string, JsonElement> expectedProperties = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "plan", JsonSerializer.SerializeToElement("bar") },
         };
         Dictionary<string, JsonElement> expectedUserProfile = new()
         {
@@ -92,7 +92,7 @@ public class TenantUpdateParamsTest : TestBase
     [Fact]
     public void OptionalNullableParamsUnsetAreNotSet_Works()
     {
-        var parameters = new TenantUpdateParams { TenantID = "tenant_id", Name = "name" };
+        var parameters = new TenantUpdateParams { TenantID = "tenant_id", Name = "Acme Corp" };
 
         Assert.Null(parameters.BrandID);
         Assert.False(parameters.RawBodyData.ContainsKey("brand_id"));
@@ -112,7 +112,7 @@ public class TenantUpdateParamsTest : TestBase
         var parameters = new TenantUpdateParams
         {
             TenantID = "tenant_id",
-            Name = "name",
+            Name = "Acme Corp",
 
             BrandID = null,
             DefaultPreferences = null,
@@ -136,7 +136,7 @@ public class TenantUpdateParamsTest : TestBase
     [Fact]
     public void Url_Works()
     {
-        TenantUpdateParams parameters = new() { TenantID = "tenant_id", Name = "name" };
+        TenantUpdateParams parameters = new() { TenantID = "tenant_id", Name = "Acme Corp" };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
 
@@ -149,8 +149,8 @@ public class TenantUpdateParamsTest : TestBase
         var parameters = new TenantUpdateParams
         {
             TenantID = "tenant_id",
-            Name = "name",
-            BrandID = "brand_id",
+            Name = "Acme Corp",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
             DefaultPreferences = new()
             {
                 Items =
@@ -167,7 +167,7 @@ public class TenantUpdateParamsTest : TestBase
             ParentTenantID = "parent_tenant_id",
             Properties = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "plan", JsonSerializer.SerializeToElement("bar") },
             },
             UserProfile = new Dictionary<string, JsonElement>()
             {

--- a/src/TryCourier.Tests/Models/Translations/TranslationUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Translations/TranslationUpdateParamsTest.cs
@@ -12,12 +12,12 @@ public class TranslationUpdateParamsTest : TestBase
         {
             Domain = "domain",
             Locale = "locale",
-            Body = "body",
+            Body = "msgid \"Hello\"\nmsgstr \"Hola\"",
         };
 
         string expectedDomain = "domain";
         string expectedLocale = "locale";
-        string expectedBody = "body";
+        string expectedBody = "msgid \"Hello\"\nmsgstr \"Hola\"";
 
         Assert.Equal(expectedDomain, parameters.Domain);
         Assert.Equal(expectedLocale, parameters.Locale);
@@ -31,7 +31,7 @@ public class TranslationUpdateParamsTest : TestBase
         {
             Domain = "domain",
             Locale = "locale",
-            Body = "body",
+            Body = "msgid \"Hello\"\nmsgstr \"Hola\"",
         };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
@@ -48,7 +48,7 @@ public class TranslationUpdateParamsTest : TestBase
         {
             Domain = "domain",
             Locale = "locale",
-            Body = "body",
+            Body = "msgid \"Hello\"\nmsgstr \"Hola\"",
         };
 
         TranslationUpdateParams copied = new(parameters);

--- a/src/TryCourier.Tests/Models/Users/Tenants/TenantAddMultipleParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Users/Tenants/TenantAddMultipleParamsTest.cs
@@ -18,7 +18,17 @@ public class TenantAddMultipleParamsTest : TestBase
             [
                 new()
                 {
-                    TenantID = "tenant_id",
+                    TenantID = "tenant_abc",
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Type = Tenants::Type.User,
+                    UserID = "user_id",
+                },
+                new()
+                {
+                    TenantID = "tenant_def",
                     Profile = new Dictionary<string, JsonElement>()
                     {
                         { "foo", JsonSerializer.SerializeToElement("bar") },
@@ -34,7 +44,17 @@ public class TenantAddMultipleParamsTest : TestBase
         [
             new()
             {
-                TenantID = "tenant_id",
+                TenantID = "tenant_abc",
+                Profile = new Dictionary<string, JsonElement>()
+                {
+                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                },
+                Type = Tenants::Type.User,
+                UserID = "user_id",
+            },
+            new()
+            {
+                TenantID = "tenant_def",
                 Profile = new Dictionary<string, JsonElement>()
                 {
                     { "foo", JsonSerializer.SerializeToElement("bar") },
@@ -62,7 +82,17 @@ public class TenantAddMultipleParamsTest : TestBase
             [
                 new()
                 {
-                    TenantID = "tenant_id",
+                    TenantID = "tenant_abc",
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Type = Tenants::Type.User,
+                    UserID = "user_id",
+                },
+                new()
+                {
+                    TenantID = "tenant_def",
                     Profile = new Dictionary<string, JsonElement>()
                     {
                         { "foo", JsonSerializer.SerializeToElement("bar") },
@@ -90,7 +120,17 @@ public class TenantAddMultipleParamsTest : TestBase
             [
                 new()
                 {
-                    TenantID = "tenant_id",
+                    TenantID = "tenant_abc",
+                    Profile = new Dictionary<string, JsonElement>()
+                    {
+                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                    },
+                    Type = Tenants::Type.User,
+                    UserID = "user_id",
+                },
+                new()
+                {
+                    TenantID = "tenant_def",
                     Profile = new Dictionary<string, JsonElement>()
                     {
                         { "foo", JsonSerializer.SerializeToElement("bar") },

--- a/src/TryCourier.Tests/Models/Users/Tenants/TenantAddSingleParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Users/Tenants/TenantAddSingleParamsTest.cs
@@ -16,7 +16,7 @@ public class TenantAddSingleParamsTest : TestBase
             TenantID = "tenant_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "role", JsonSerializer.SerializeToElement("bar") },
             },
         };
 
@@ -24,7 +24,7 @@ public class TenantAddSingleParamsTest : TestBase
         string expectedTenantID = "tenant_id";
         Dictionary<string, JsonElement> expectedProfile = new()
         {
-            { "foo", JsonSerializer.SerializeToElement("bar") },
+            { "role", JsonSerializer.SerializeToElement("bar") },
         };
 
         Assert.Equal(expectedUserID, parameters.UserID);
@@ -87,7 +87,7 @@ public class TenantAddSingleParamsTest : TestBase
             TenantID = "tenant_id",
             Profile = new Dictionary<string, JsonElement>()
             {
-                { "foo", JsonSerializer.SerializeToElement("bar") },
+                { "role", JsonSerializer.SerializeToElement("bar") },
             },
         };
 

--- a/src/TryCourier.Tests/Models/Users/Tokens/TokenAddSingleParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Users/Tokens/TokenAddSingleParamsTest.cs
@@ -19,7 +19,7 @@ public class TokenAddSingleParamsTest : TestBase
             Device = new()
             {
                 AdID = "ad_id",
-                AppID = "app_id",
+                AppID = "com.example.app",
                 DeviceID = "device_id",
                 Manufacturer = "manufacturer",
                 Model = "model",
@@ -42,7 +42,7 @@ public class TokenAddSingleParamsTest : TestBase
         Device expectedDevice = new()
         {
             AdID = "ad_id",
-            AppID = "app_id",
+            AppID = "com.example.app",
             DeviceID = "device_id",
             Manufacturer = "manufacturer",
             Model = "model",
@@ -79,7 +79,7 @@ public class TokenAddSingleParamsTest : TestBase
             Device = new()
             {
                 AdID = "ad_id",
-                AppID = "app_id",
+                AppID = "com.example.app",
                 DeviceID = "device_id",
                 Manufacturer = "manufacturer",
                 Model = "model",
@@ -110,7 +110,7 @@ public class TokenAddSingleParamsTest : TestBase
             Device = new()
             {
                 AdID = "ad_id",
-                AppID = "app_id",
+                AppID = "com.example.app",
                 DeviceID = "device_id",
                 Manufacturer = "manufacturer",
                 Model = "model",
@@ -203,7 +203,7 @@ public class TokenAddSingleParamsTest : TestBase
             Device = new()
             {
                 AdID = "ad_id",
-                AppID = "app_id",
+                AppID = "com.example.app",
                 DeviceID = "device_id",
                 Manufacturer = "manufacturer",
                 Model = "model",

--- a/src/TryCourier.Tests/Models/Users/Tokens/TokenUpdateParamsTest.cs
+++ b/src/TryCourier.Tests/Models/Users/Tokens/TokenUpdateParamsTest.cs
@@ -19,9 +19,9 @@ public class TokenUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/expiry_date",
+                    Value = "2024-12-31T00:00:00.000Z",
                 },
             ],
         };
@@ -32,9 +32,9 @@ public class TokenUpdateParamsTest : TestBase
         [
             new()
             {
-                Op = "op",
-                Path = "path",
-                Value = "value",
+                Op = "replace",
+                Path = "/expiry_date",
+                Value = "2024-12-31T00:00:00.000Z",
             },
         ];
 
@@ -58,9 +58,9 @@ public class TokenUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/expiry_date",
+                    Value = "2024-12-31T00:00:00.000Z",
                 },
             ],
         };
@@ -83,9 +83,9 @@ public class TokenUpdateParamsTest : TestBase
             [
                 new()
                 {
-                    Op = "op",
-                    Path = "path",
-                    Value = "value",
+                    Op = "replace",
+                    Path = "/expiry_date",
+                    Value = "2024-12-31T00:00:00.000Z",
                 },
             ],
         };

--- a/src/TryCourier.Tests/Models/WorkspacePreferences/Topics/TopicReplaceParamsTest.cs
+++ b/src/TryCourier.Tests/Models/WorkspacePreferences/Topics/TopicReplaceParamsTest.cs
@@ -17,12 +17,12 @@ public class TopicReplaceParamsTest : TestBase
         {
             SectionID = "section_id",
             TopicID = "topic_id",
-            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-            Name = "name",
-            AllowedPreferences = [TopicReplaceParamsAllowedPreference.Snooze],
+            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+            Name = "Product Updates",
+            AllowedPreferences = [TopicReplaceParamsAllowedPreference.ChannelPreferences],
             Description = "description",
             IncludeUnsubscribeHeader = true,
-            RoutingOptions = [ChannelClassification.DirectMessage],
+            RoutingOptions = [ChannelClassification.Email, ChannelClassification.Inbox],
             TopicData = new Dictionary<string, JsonElement>()
             {
                 { "foo", JsonSerializer.SerializeToElement("bar") },
@@ -32,17 +32,18 @@ public class TopicReplaceParamsTest : TestBase
         string expectedSectionID = "section_id";
         string expectedTopicID = "topic_id";
         ApiEnum<string, TopicReplaceParamsDefaultStatus> expectedDefaultStatus =
-            TopicReplaceParamsDefaultStatus.OptedOut;
-        string expectedName = "name";
+            TopicReplaceParamsDefaultStatus.OptedIn;
+        string expectedName = "Product Updates";
         List<ApiEnum<string, TopicReplaceParamsAllowedPreference>> expectedAllowedPreferences =
         [
-            TopicReplaceParamsAllowedPreference.Snooze,
+            TopicReplaceParamsAllowedPreference.ChannelPreferences,
         ];
         string expectedDescription = "description";
         bool expectedIncludeUnsubscribeHeader = true;
         List<ApiEnum<string, ChannelClassification>> expectedRoutingOptions =
         [
-            ChannelClassification.DirectMessage,
+            ChannelClassification.Email,
+            ChannelClassification.Inbox,
         ];
         Dictionary<string, JsonElement> expectedTopicData = new()
         {
@@ -84,8 +85,8 @@ public class TopicReplaceParamsTest : TestBase
         {
             SectionID = "section_id",
             TopicID = "topic_id",
-            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-            Name = "name",
+            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+            Name = "Product Updates",
         };
 
         Assert.Null(parameters.AllowedPreferences);
@@ -107,8 +108,8 @@ public class TopicReplaceParamsTest : TestBase
         {
             SectionID = "section_id",
             TopicID = "topic_id",
-            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-            Name = "name",
+            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+            Name = "Product Updates",
 
             AllowedPreferences = null,
             Description = null,
@@ -136,8 +137,8 @@ public class TopicReplaceParamsTest : TestBase
         {
             SectionID = "section_id",
             TopicID = "topic_id",
-            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-            Name = "name",
+            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+            Name = "Product Updates",
         };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
@@ -157,12 +158,12 @@ public class TopicReplaceParamsTest : TestBase
         {
             SectionID = "section_id",
             TopicID = "topic_id",
-            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-            Name = "name",
-            AllowedPreferences = [TopicReplaceParamsAllowedPreference.Snooze],
+            DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+            Name = "Product Updates",
+            AllowedPreferences = [TopicReplaceParamsAllowedPreference.ChannelPreferences],
             Description = "description",
             IncludeUnsubscribeHeader = true,
-            RoutingOptions = [ChannelClassification.DirectMessage],
+            RoutingOptions = [ChannelClassification.Email, ChannelClassification.Inbox],
             TopicData = new Dictionary<string, JsonElement>()
             {
                 { "foo", JsonSerializer.SerializeToElement("bar") },

--- a/src/TryCourier.Tests/Models/WorkspacePreferences/WorkspacePreferencePublishParamsTest.cs
+++ b/src/TryCourier.Tests/Models/WorkspacePreferences/WorkspacePreferencePublishParamsTest.cs
@@ -11,16 +11,16 @@ public class WorkspacePreferencePublishParamsTest : TestBase
     {
         var parameters = new WorkspacePreferencePublishParams
         {
-            BrandID = "brand_id",
-            Description = "description",
-            Heading = "heading",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            Description = "Choose what you hear from us about.",
+            Heading = "Notification Preferences",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };
 
-        string expectedBrandID = "brand_id";
-        string expectedDescription = "description";
-        string expectedHeading = "heading";
+        string expectedBrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag";
+        string expectedDescription = "Choose what you hear from us about.";
+        string expectedHeading = "Notification Preferences";
         string expectedIdempotencyKey = "order-ORD-456-user-123";
         string expectedXIdempotencyExpiration = "1785312000";
 
@@ -36,9 +36,9 @@ public class WorkspacePreferencePublishParamsTest : TestBase
     {
         var parameters = new WorkspacePreferencePublishParams
         {
-            BrandID = "brand_id",
-            Description = "description",
-            Heading = "heading",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            Description = "Choose what you hear from us about.",
+            Heading = "Notification Preferences",
         };
 
         Assert.Null(parameters.IdempotencyKey);
@@ -52,9 +52,9 @@ public class WorkspacePreferencePublishParamsTest : TestBase
     {
         var parameters = new WorkspacePreferencePublishParams
         {
-            BrandID = "brand_id",
-            Description = "description",
-            Heading = "heading",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            Description = "Choose what you hear from us about.",
+            Heading = "Notification Preferences",
 
             // Null should be interpreted as omitted for these properties
             IdempotencyKey = null,
@@ -141,9 +141,9 @@ public class WorkspacePreferencePublishParamsTest : TestBase
     {
         var parameters = new WorkspacePreferencePublishParams
         {
-            BrandID = "brand_id",
-            Description = "description",
-            Heading = "heading",
+            BrandID = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
+            Description = "Choose what you hear from us about.",
+            Heading = "Notification Preferences",
             IdempotencyKey = "order-ORD-456-user-123",
             XIdempotencyExpiration = "1785312000",
         };

--- a/src/TryCourier.Tests/Models/WorkspacePreferences/WorkspacePreferenceReplaceParamsTest.cs
+++ b/src/TryCourier.Tests/Models/WorkspacePreferences/WorkspacePreferenceReplaceParamsTest.cs
@@ -14,19 +14,20 @@ public class WorkspacePreferenceReplaceParamsTest : TestBase
         var parameters = new WorkspacePreferenceReplaceParams
         {
             SectionID = "section_id",
-            Name = "name",
+            Name = "Account Notifications",
             Description = "description",
             HasCustomRouting = true,
-            RoutingOptions = [ChannelClassification.DirectMessage],
+            RoutingOptions = [ChannelClassification.Email, ChannelClassification.Push],
         };
 
         string expectedSectionID = "section_id";
-        string expectedName = "name";
+        string expectedName = "Account Notifications";
         string expectedDescription = "description";
         bool expectedHasCustomRouting = true;
         List<ApiEnum<string, ChannelClassification>> expectedRoutingOptions =
         [
-            ChannelClassification.DirectMessage,
+            ChannelClassification.Email,
+            ChannelClassification.Push,
         ];
 
         Assert.Equal(expectedSectionID, parameters.SectionID);
@@ -47,7 +48,7 @@ public class WorkspacePreferenceReplaceParamsTest : TestBase
         var parameters = new WorkspacePreferenceReplaceParams
         {
             SectionID = "section_id",
-            Name = "name",
+            Name = "Account Notifications",
         };
 
         Assert.Null(parameters.Description);
@@ -64,7 +65,7 @@ public class WorkspacePreferenceReplaceParamsTest : TestBase
         var parameters = new WorkspacePreferenceReplaceParams
         {
             SectionID = "section_id",
-            Name = "name",
+            Name = "Account Notifications",
 
             Description = null,
             HasCustomRouting = null,
@@ -85,7 +86,7 @@ public class WorkspacePreferenceReplaceParamsTest : TestBase
         WorkspacePreferenceReplaceParams parameters = new()
         {
             SectionID = "section_id",
-            Name = "name",
+            Name = "Account Notifications",
         };
 
         var url = parameters.Url(new() { ApiKey = "My API Key" });
@@ -104,10 +105,10 @@ public class WorkspacePreferenceReplaceParamsTest : TestBase
         var parameters = new WorkspacePreferenceReplaceParams
         {
             SectionID = "section_id",
-            Name = "name",
+            Name = "Account Notifications",
             Description = "description",
             HasCustomRouting = true,
-            RoutingOptions = [ChannelClassification.DirectMessage],
+            RoutingOptions = [ChannelClassification.Email, ChannelClassification.Push],
         };
 
         WorkspacePreferenceReplaceParams copied = new(parameters);

--- a/src/TryCourier.Tests/Services/Automations/InvokeServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Automations/InvokeServiceTest.cs
@@ -52,7 +52,7 @@ public class InvokeServiceTest : TestBase
     {
         var automationInvokeResponse = await this.client.Automations.Invoke.InvokeByTemplate(
             "templateId",
-            new() { Recipient = "recipient" },
+            new() { Recipient = "user_abc" },
             TestContext.Current.CancellationToken
         );
         automationInvokeResponse.Validate();

--- a/src/TryCourier.Tests/Services/BrandServiceTest.cs
+++ b/src/TryCourier.Tests/Services/BrandServiceTest.cs
@@ -85,7 +85,7 @@ public class BrandServiceTest : TestBase
     {
         var brand = await this.client.Brands.Update(
             "brand_id",
-            new() { Name = "name" },
+            new() { Name = "My Brand" },
             TestContext.Current.CancellationToken
         );
         brand.Validate();

--- a/src/TryCourier.Tests/Services/BulkServiceTest.cs
+++ b/src/TryCourier.Tests/Services/BulkServiceTest.cs
@@ -18,7 +18,13 @@ public class BulkServiceTest : TestBase
                 [
                     new()
                     {
-                        Data = JsonSerializer.Deserialize<JsonElement>("{}"),
+                        Data = JsonSerializer.Deserialize<JsonElement>(
+                            """
+                            {
+                              "name": "Jane"
+                            }
+                            """
+                        ),
                         Preferences = new()
                         {
                             Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -54,9 +60,9 @@ public class BulkServiceTest : TestBase
                         },
                         Profile = new Dictionary<string, JsonElement>()
                         {
-                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                            { "email", JsonSerializer.SerializeToElement("bar") },
                         },
-                        Recipient = "recipient",
+                        Recipient = "user_abc",
                         To = new()
                         {
                             AccountID = "account_id",
@@ -123,12 +129,12 @@ public class BulkServiceTest : TestBase
             {
                 Message = new()
                 {
-                    Event = "event",
-                    Brand = "brand",
+                    Event = "welcome-series",
+                    Brand = "bnd_01kx4mrd0pfzw8wt7pn7p2fzag",
                     Content = new ElementalContentSugar() { Body = "body", Title = "title" },
                     Data = new Dictionary<string, JsonElement>()
                     {
-                        { "foo", JsonSerializer.SerializeToElement("bar") },
+                        { "campaign", JsonSerializer.SerializeToElement("bar") },
                     },
                     Locale = new Dictionary<string, IReadOnlyDictionary<string, JsonElement>>()
                     {

--- a/src/TryCourier.Tests/Services/ListServiceTest.cs
+++ b/src/TryCourier.Tests/Services/ListServiceTest.cs
@@ -20,7 +20,7 @@ public class ListServiceTest : TestBase
     {
         await this.client.Lists.Update(
             "list_id",
-            new() { Name = "name" },
+            new() { Name = "Product Updates" },
             TestContext.Current.CancellationToken
         );
     }

--- a/src/TryCourier.Tests/Services/Lists/SubscriptionServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Lists/SubscriptionServiceTest.cs
@@ -28,7 +28,44 @@ public class SubscriptionServiceTest : TestBase
                 [
                     new()
                     {
-                        RecipientID = "recipientId",
+                        RecipientID = "user_abc",
+                        Preferences = new()
+                        {
+                            Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                            Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                        },
+                    },
+                    new()
+                    {
+                        RecipientID = "user_def",
                         Preferences = new()
                         {
                             Categories = new Dictionary<string, NotificationPreferenceDetails>()
@@ -80,7 +117,44 @@ public class SubscriptionServiceTest : TestBase
                 [
                     new()
                     {
-                        RecipientID = "recipientId",
+                        RecipientID = "user_abc",
+                        Preferences = new()
+                        {
+                            Categories = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                            Notifications = new Dictionary<string, NotificationPreferenceDetails>()
+                            {
+                                {
+                                    "foo",
+                                    new()
+                                    {
+                                        Status = PreferenceStatus.OptedIn,
+                                        ChannelPreferences =
+                                        [
+                                            new(ChannelClassification.DirectMessage),
+                                        ],
+                                        Rules = [new() { Until = "until", Start = "start" }],
+                                    }
+                                },
+                            },
+                        },
+                    },
+                    new()
+                    {
+                        RecipientID = "user_def",
                         Preferences = new()
                         {
                             Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Services/Notifications/CheckServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Notifications/CheckServiceTest.cs
@@ -17,7 +17,7 @@ public class CheckServiceTest : TestBase
                 [
                     new()
                     {
-                        ID = "id",
+                        ID = "abc-123",
                         Status = Status.Resolved,
                         Type = Type.Custom,
                     },

--- a/src/TryCourier.Tests/Services/ProfileServiceTest.cs
+++ b/src/TryCourier.Tests/Services/ProfileServiceTest.cs
@@ -15,7 +15,8 @@ public class ProfileServiceTest : TestBase
             {
                 Profile = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "email", JsonSerializer.SerializeToElement("bar") },
+                    { "phone_number", JsonSerializer.SerializeToElement("bar") },
                 },
             },
             TestContext.Current.CancellationToken
@@ -45,9 +46,9 @@ public class ProfileServiceTest : TestBase
                 [
                     new()
                     {
-                        Op = "op",
-                        Path = "path",
-                        Value = "value",
+                        Op = "replace",
+                        Path = "/email",
+                        Value = "jdoe@example.com",
                     },
                 ],
             },
@@ -70,7 +71,9 @@ public class ProfileServiceTest : TestBase
             {
                 Profile = new Dictionary<string, JsonElement>()
                 {
-                    { "foo", JsonSerializer.SerializeToElement("bar") },
+                    { "email", JsonSerializer.SerializeToElement("bar") },
+                    { "phone_number", JsonSerializer.SerializeToElement("bar") },
+                    { "locale", JsonSerializer.SerializeToElement("bar") },
                 },
             },
             TestContext.Current.CancellationToken

--- a/src/TryCourier.Tests/Services/Profiles/ListServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Profiles/ListServiceTest.cs
@@ -39,7 +39,7 @@ public class ListServiceTest : TestBase
                 [
                     new()
                     {
-                        ListID = "listId",
+                        ListID = "example.list.id",
                         Preferences = new()
                         {
                             Categories = new Dictionary<string, NotificationPreferenceDetails>()

--- a/src/TryCourier.Tests/Services/ProviderServiceTest.cs
+++ b/src/TryCourier.Tests/Services/ProviderServiceTest.cs
@@ -8,7 +8,7 @@ public class ProviderServiceTest : TestBase
     public async Task Create_Works()
     {
         var provider = await this.client.Providers.Create(
-            new() { Provider = "provider" },
+            new() { Provider = "sendgrid" },
             TestContext.Current.CancellationToken
         );
         provider.Validate();
@@ -30,7 +30,7 @@ public class ProviderServiceTest : TestBase
     {
         var provider = await this.client.Providers.Update(
             "id",
-            new() { Provider = "provider" },
+            new() { Provider = "sendgrid" },
             TestContext.Current.CancellationToken
         );
         provider.Validate();

--- a/src/TryCourier.Tests/Services/TenantServiceTest.cs
+++ b/src/TryCourier.Tests/Services/TenantServiceTest.cs
@@ -20,7 +20,7 @@ public class TenantServiceTest : TestBase
     {
         var tenant = await this.client.Tenants.Update(
             "tenant_id",
-            new() { Name = "name" },
+            new() { Name = "Acme Corp" },
             TestContext.Current.CancellationToken
         );
         tenant.Validate();

--- a/src/TryCourier.Tests/Services/Tenants/TemplateServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Tenants/TemplateServiceTest.cs
@@ -73,7 +73,7 @@ public class TemplateServiceTest : TestBase
                                 Type = ElementalTextNodeWithTypeIntersectionMember1Type.Text,
                             },
                         ],
-                        Version = "version",
+                        Version = "2022-01-01",
                     },
                     Channels = new Dictionary<string, Channel>()
                     {
@@ -130,7 +130,7 @@ public class TemplateServiceTest : TestBase
                             }
                         },
                     },
-                    Routing = new() { Channels = ["string"], Method = Method.All },
+                    Routing = new() { Channels = ["email"], Method = Method.Single },
                 },
             },
             TestContext.Current.CancellationToken

--- a/src/TryCourier.Tests/Services/TranslationServiceTest.cs
+++ b/src/TryCourier.Tests/Services/TranslationServiceTest.cs
@@ -19,7 +19,7 @@ public class TranslationServiceTest : TestBase
     {
         await this.client.Translations.Update(
             "locale",
-            new() { Domain = "domain", Body = "body" },
+            new() { Domain = "domain", Body = "msgid \"Hello\"\nmsgstr \"Hola\"" },
             TestContext.Current.CancellationToken
         );
     }

--- a/src/TryCourier.Tests/Services/Users/TenantServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Users/TenantServiceTest.cs
@@ -29,7 +29,17 @@ public class TenantServiceTest : TestBase
                 [
                     new()
                     {
-                        TenantID = "tenant_id",
+                        TenantID = "tenant_abc",
+                        Profile = new Dictionary<string, JsonElement>()
+                        {
+                            { "foo", JsonSerializer.SerializeToElement("bar") },
+                        },
+                        Type = Type.User,
+                        UserID = "user_id",
+                    },
+                    new()
+                    {
+                        TenantID = "tenant_def",
                         Profile = new Dictionary<string, JsonElement>()
                         {
                             { "foo", JsonSerializer.SerializeToElement("bar") },

--- a/src/TryCourier.Tests/Services/Users/TokenServiceTest.cs
+++ b/src/TryCourier.Tests/Services/Users/TokenServiceTest.cs
@@ -28,9 +28,9 @@ public class TokenServiceTest : TestBase
                 [
                     new()
                     {
-                        Op = "op",
-                        Path = "path",
-                        Value = "value",
+                        Op = "replace",
+                        Path = "/expiry_date",
+                        Value = "2024-12-31T00:00:00.000Z",
                     },
                 ],
             },

--- a/src/TryCourier.Tests/Services/WorkspacePreferenceServiceTest.cs
+++ b/src/TryCourier.Tests/Services/WorkspacePreferenceServiceTest.cs
@@ -60,7 +60,7 @@ public class WorkspacePreferenceServiceTest : TestBase
     {
         var workspacePreferenceGetResponse = await this.client.WorkspacePreferences.Replace(
             "section_id",
-            new() { Name = "name" },
+            new() { Name = "Account Notifications" },
             TestContext.Current.CancellationToken
         );
         workspacePreferenceGetResponse.Validate();

--- a/src/TryCourier.Tests/Services/WorkspacePreferences/TopicServiceTest.cs
+++ b/src/TryCourier.Tests/Services/WorkspacePreferences/TopicServiceTest.cs
@@ -60,8 +60,8 @@ public class TopicServiceTest : TestBase
                 new()
                 {
                     SectionID = "section_id",
-                    DefaultStatus = TopicReplaceParamsDefaultStatus.OptedOut,
-                    Name = "name",
+                    DefaultStatus = TopicReplaceParamsDefaultStatus.OptedIn,
+                    Name = "Product Updates",
                 },
                 TestContext.Current.CancellationToken
             );


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

43 files changed, 789 insertions(+), 274 deletions(-)

<details><summary>Files</summary>

```
 src/TryCourier.Tests/Models/Bulk/BulkCreateJobParamsTest.cs     |  24 +--
 src/TryCourier.Tests/Models/Lists/ListUpdateParamsTest.cs       |  12 +-
 .../Models/Lists/Subscriptions/SubscriptionAddParamsTest.cs     | 231 +++++++++++++++++++++++++++-
 .../Lists/Subscriptions/SubscriptionSubscribeParamsTest.cs      | 132 +++++++++++++++-
 .../Lists/Subscriptions/SubscriptionSubscribeUserParamsTest.cs  |   6 +-
 .../Models/Notifications/Checks/CheckUpdateParamsTest.cs        |   8 +-
 .../Models/Profiles/Lists/ListSubscribeParamsTest.cs            |  14 +-
 src/TryCourier.Tests/Models/Profiles/ProfileCreateParamsTest.cs |  21 ++-
 .../Models/Profiles/ProfileReplaceParamsTest.cs                 |  16 +-
 src/TryCourier.Tests/Models/Profiles/ProfileUpdateParamsTest.cs |  24 +--
 .../Models/Providers/ProviderCreateParamsTest.cs                |  26 ++--
 .../Models/Providers/ProviderUpdateParamsTest.cs                |  24 +--
 .../Models/Tenants/Templates/TemplatePublishParamsTest.cs       |   6 +-
 .../Models/Tenants/Templates/TemplateReplaceParamsTest.cs       |  24 +--
 src/TryCourier.Tests/Models/Tenants/TenantUpdateParamsTest.cs   |  24 +--
 .../Models/Translations/TranslationUpdateParamsTest.cs          |   8 +-
 .../Models/Users/Tenants/TenantAddMultipleParamsTest.cs         |  48 +++++-
 .../Models/Users/Tenants/TenantAddSingleParamsTest.cs           |   6 +-
 .../Models/Users/Tokens/TokenAddSingleParamsTest.cs             |  10 +-
 .../Models/Users/Tokens/TokenUpdateParamsTest.cs                |  24 +--
 .../WorkspacePreferences/Topics/TopicReplaceParamsTest.cs       |  37 ++---
 .../WorkspacePreferencePublishParamsTest.cs                     |  30 ++--
 .../WorkspacePreferenceReplaceParamsTest.cs                     |  19 +--
 src/TryCourier.Tests/Services/Automations/InvokeServiceTest.cs  |   2 +-
 src/TryCourier.Tests/Services/BrandServiceTest.cs               |   2 +-
 src/TryCourier.Tests/Services/BulkServiceTest.cs                |  18 ++-
 src/TryCourier.Tests/Services/ListServiceTest.cs                |   2 +-
 src/TryCourier.Tests/Services/Lists/SubscriptionServiceTest.cs  |  78 +++++++++-
 src/TryCourier.Tests/Services/Notifications/CheckServiceTest.cs |   2 +-
 src/TryCourier.Tests/Services/ProfileServiceTest.cs             |  13 +-
 src/TryCourier.Tests/Services/Profiles/ListServiceTest.cs       |   2 +-
 src/TryCourier.Tests/Services/ProviderServiceTest.cs            |   4 +-
 src/TryCourier.Tests/Services/TenantServiceTest.cs              |   2 +-
 src/TryCourier.Tests/Services/Tenants/TemplateServiceTest.cs    |   4 +-
 src/TryCourier.Tests/Services/TranslationServiceTest.cs         |   2 +-
 src/TryCourier.Tests/Services/Users/TenantServiceTest.cs        |  12 +-
 src/TryCourier.Tests/Services/Users/TokenServiceTest.cs         |   6 +-
 src/TryCourier.Tests/Services/WorkspacePreferenceServiceTest.cs |   2 +-
 .../Services/WorkspacePreferences/TopicServiceTest.cs           |   4 +-
 43 files changed, 789 insertions(+), 274 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
