### PR TITLE
docs(api): describe every broadcast id path parameter

### DIFF
--- a/src/TryCourier/TryCourier.csproj
+++ b/src/TryCourier/TryCourier.csproj
@@ -9,12 +9,12 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="TryCourier.Tests"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.9"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <InternalsVisibleTo Include="TryCourier.Tests" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 5 insertions(+), 5 deletions(-)

<details><summary>Files</summary>

```
 src/TryCourier/TryCourier.csproj | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
