### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/src/TryCourier/Models/Bulk/BulkListUsersParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkListUsersParams.cs
@@ -9,7 +9,8 @@ using TryCourier.Core;
 namespace TryCourier.Models.Bulk;
 
 /// <summary>
-/// Get Bulk Job Users
+/// Returns the users ingested into a bulk job with paging, each carrying the status
+/// Courier recorded for it and the id of the message it produced.
 ///
 /// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
 /// breaking changes in non-major versions. We may add new methods in the future that

--- a/src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs
@@ -9,7 +9,9 @@ using TryCourier.Core;
 namespace TryCourier.Models.Bulk;
 
 /// <summary>
-/// Get a bulk job
+/// Returns a bulk job's message definition, its status — CREATED, PROCESSING, COMPLETED,
+/// or ERROR — and running counts of users received, messages enqueued, and failures.
+/// Poll it to follow a job through to completion.
 ///
 /// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
 /// breaking changes in non-major versions. We may add new methods in the future that

--- a/src/TryCourier/Models/Bulk/BulkRunJobParams.cs
+++ b/src/TryCourier/Models/Bulk/BulkRunJobParams.cs
@@ -9,7 +9,9 @@ using TryCourier.Core;
 namespace TryCourier.Models.Bulk;
 
 /// <summary>
-/// Run a bulk job
+/// Starts processing a bulk job, sending to every user ingested into it. Returns
+/// 204 immediately; the job runs asynchronously, so poll the job to watch its status
+/// and counts.
 ///
 /// <para>NOTE: Do not inherit from this type outside the SDK unless you're okay with
 /// breaking changes in non-major versions. We may add new methods in the future that

--- a/src/TryCourier/Services/IBulkService.cs
+++ b/src/TryCourier/Services/IBulkService.cs
@@ -57,7 +57,8 @@ public interface IBulkService
     );
 
     /// <summary>
-    /// Get Bulk Job Users
+    /// Returns the users ingested into a bulk job with paging, each carrying the status
+    /// Courier recorded for it and the id of the message it produced.
     /// </summary>
     Task<BulkListUsersResponse> ListUsers(
         BulkListUsersParams parameters,
@@ -72,7 +73,9 @@ public interface IBulkService
     );
 
     /// <summary>
-    /// Get a bulk job
+    /// Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+    /// COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+    /// and failures. Poll it to follow a job through to completion.
     /// </summary>
     Task<BulkRetrieveJobResponse> RetrieveJob(
         BulkRetrieveJobParams parameters,
@@ -87,7 +90,9 @@ public interface IBulkService
     );
 
     /// <summary>
-    /// Run a bulk job
+    /// Starts processing a bulk job, sending to every user ingested into it. Returns
+    /// 204 immediately; the job runs asynchronously, so poll the job to watch its
+    /// status and counts.
     /// </summary>
     Task RunJob(BulkRunJobParams parameters, CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

4 files changed, 16 insertions(+), 6 deletions(-)

<details><summary>Files</summary>

```
 src/TryCourier/Models/Bulk/BulkListUsersParams.cs   |  3 ++-
 src/TryCourier/Models/Bulk/BulkRetrieveJobParams.cs |  4 +++-
 src/TryCourier/Models/Bulk/BulkRunJobParams.cs      |  4 +++-
 src/TryCourier/Services/IBulkService.cs             | 11 ++++++++---
 4 files changed, 16 insertions(+), 6 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
