### PR TITLE
feat(api)!: nest the AWS SNS target_arn under aws_sns on the user profile

### DIFF
--- a/src/TryCourier.Tests/Models/AwsSnsTest.cs
+++ b/src/TryCourier.Tests/Models/AwsSnsTest.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using TryCourier.Core;
+using TryCourier.Models;
+
+namespace TryCourier.Tests.Models;
+
+public class AwsSnsTest : TestBase
+{
+    [Fact]
+    public void FieldRoundtrip_Works()
+    {
+        var model = new AwsSns { TargetArn = "target_arn" };
+
+        string expectedTargetArn = "target_arn";
+
+        Assert.Equal(expectedTargetArn, model.TargetArn);
+    }
+
+    [Fact]
+    public void SerializationRoundtrip_Works()
+    {
+        var model = new AwsSns { TargetArn = "target_arn" };
+
+        string json = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<AwsSns>(json, ModelBase.SerializerOptions);
+
+        Assert.Equal(model, deserialized);
+    }
+
+    [Fact]
+    public void FieldRoundtripThroughSerialization_Works()
+    {
+        var model = new AwsSns { TargetArn = "target_arn" };
+
+        string element = JsonSerializer.Serialize(model, ModelBase.SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<AwsSns>(element, ModelBase.SerializerOptions);
+        Assert.NotNull(deserialized);
+
+        string expectedTargetArn = "target_arn";
+
+        Assert.Equal(expectedTargetArn, deserialized.TargetArn);
+    }
+
+    [Fact]
+    public void Validation_Works()
+    {
+        var model = new AwsSns { TargetArn = "target_arn" };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void CopyConstructor_Works()
+    {
+        var model = new AwsSns { TargetArn = "target_arn" };
+
+        AwsSns copied = new(model);
+
+        Assert.Equal(model, copied);
+    }
+}

--- a/src/TryCourier.Tests/Models/UserProfileTest.cs
+++ b/src/TryCourier.Tests/Models/UserProfileTest.cs
@@ -23,6 +23,7 @@ public class UserProfileTest : TestBase
             },
             Airship = new() { Audience = new("named_user"), DeviceTypes = ["string"] },
             Apn = "apn",
+            AwsSns = new("target_arn"),
             Birthdate = "birthdate",
             Custom = new Dictionary<string, JsonElement>()
             {
@@ -55,7 +56,6 @@ public class UserProfileTest : TestBase
             Profile = "profile",
             Slack = new SendToSlackChannel() { AccessToken = "access_token", Channel = "channel" },
             Sub = "sub",
-            TargetArn = "target_arn",
             UpdatedAt = "updated_at",
             Website = "website",
             Zoneinfo = "zoneinfo",
@@ -76,6 +76,7 @@ public class UserProfileTest : TestBase
             DeviceTypes = ["string"],
         };
         string expectedApn = "apn";
+        AwsSns expectedAwsSns = new("target_arn");
         string expectedBirthdate = "birthdate";
         Dictionary<string, JsonElement> expectedCustom = new()
         {
@@ -112,7 +113,6 @@ public class UserProfileTest : TestBase
             Channel = "channel",
         };
         string expectedSub = "sub";
-        string expectedTargetArn = "target_arn";
         string expectedUpdatedAt = "updated_at";
         string expectedWebsite = "website";
         string expectedZoneinfo = "zoneinfo";
@@ -120,6 +120,7 @@ public class UserProfileTest : TestBase
         Assert.Equal(expectedAddress, model.Address);
         Assert.Equal(expectedAirship, model.Airship);
         Assert.Equal(expectedApn, model.Apn);
+        Assert.Equal(expectedAwsSns, model.AwsSns);
         Assert.Equal(expectedBirthdate, model.Birthdate);
         Assert.NotNull(model.Custom);
         Assert.Equal(expectedCustom.Count, model.Custom.Count);
@@ -151,7 +152,6 @@ public class UserProfileTest : TestBase
         Assert.Equal(expectedProfile, model.Profile);
         Assert.Equal(expectedSlack, model.Slack);
         Assert.Equal(expectedSub, model.Sub);
-        Assert.Equal(expectedTargetArn, model.TargetArn);
         Assert.Equal(expectedUpdatedAt, model.UpdatedAt);
         Assert.Equal(expectedWebsite, model.Website);
         Assert.Equal(expectedZoneinfo, model.Zoneinfo);
@@ -173,6 +173,7 @@ public class UserProfileTest : TestBase
             },
             Airship = new() { Audience = new("named_user"), DeviceTypes = ["string"] },
             Apn = "apn",
+            AwsSns = new("target_arn"),
             Birthdate = "birthdate",
             Custom = new Dictionary<string, JsonElement>()
             {
@@ -205,7 +206,6 @@ public class UserProfileTest : TestBase
             Profile = "profile",
             Slack = new SendToSlackChannel() { AccessToken = "access_token", Channel = "channel" },
             Sub = "sub",
-            TargetArn = "target_arn",
             UpdatedAt = "updated_at",
             Website = "website",
             Zoneinfo = "zoneinfo",
@@ -236,6 +236,7 @@ public class UserProfileTest : TestBase
             },
             Airship = new() { Audience = new("named_user"), DeviceTypes = ["string"] },
             Apn = "apn",
+            AwsSns = new("target_arn"),
             Birthdate = "birthdate",
             Custom = new Dictionary<string, JsonElement>()
             {
@@ -268,7 +269,6 @@ public class UserProfileTest : TestBase
             Profile = "profile",
             Slack = new SendToSlackChannel() { AccessToken = "access_token", Channel = "channel" },
             Sub = "sub",
-            TargetArn = "target_arn",
             UpdatedAt = "updated_at",
             Website = "website",
             Zoneinfo = "zoneinfo",
@@ -296,6 +296,7 @@ public class UserProfileTest : TestBase
             DeviceTypes = ["string"],
         };
         string expectedApn = "apn";
+        AwsSns expectedAwsSns = new("target_arn");
         string expectedBirthdate = "birthdate";
         Dictionary<string, JsonElement> expectedCustom = new()
         {
@@ -332,7 +333,6 @@ public class UserProfileTest : TestBase
             Channel = "channel",
         };
         string expectedSub = "sub";
-        string expectedTargetArn = "target_arn";
         string expectedUpdatedAt = "updated_at";
         string expectedWebsite = "website";
         string expectedZoneinfo = "zoneinfo";
@@ -340,6 +340,7 @@ public class UserProfileTest : TestBase
         Assert.Equal(expectedAddress, deserialized.Address);
         Assert.Equal(expectedAirship, deserialized.Airship);
         Assert.Equal(expectedApn, deserialized.Apn);
+        Assert.Equal(expectedAwsSns, deserialized.AwsSns);
         Assert.Equal(expectedBirthdate, deserialized.Birthdate);
         Assert.NotNull(deserialized.Custom);
         Assert.Equal(expectedCustom.Count, deserialized.Custom.Count);
@@ -371,7 +372,6 @@ public class UserProfileTest : TestBase
         Assert.Equal(expectedProfile, deserialized.Profile);
         Assert.Equal(expectedSlack, deserialized.Slack);
         Assert.Equal(expectedSub, deserialized.Sub);
-        Assert.Equal(expectedTargetArn, deserialized.TargetArn);
         Assert.Equal(expectedUpdatedAt, deserialized.UpdatedAt);
         Assert.Equal(expectedWebsite, deserialized.Website);
         Assert.Equal(expectedZoneinfo, deserialized.Zoneinfo);
@@ -393,6 +393,7 @@ public class UserProfileTest : TestBase
             },
             Airship = new() { Audience = new("named_user"), DeviceTypes = ["string"] },
             Apn = "apn",
+            AwsSns = new("target_arn"),
             Birthdate = "birthdate",
             Custom = new Dictionary<string, JsonElement>()
             {
@@ -425,7 +426,6 @@ public class UserProfileTest : TestBase
             Profile = "profile",
             Slack = new SendToSlackChannel() { AccessToken = "access_token", Channel = "channel" },
             Sub = "sub",
-            TargetArn = "target_arn",
             UpdatedAt = "updated_at",
             Website = "website",
             Zoneinfo = "zoneinfo",
@@ -445,6 +445,8 @@ public class UserProfileTest : TestBase
         Assert.False(model.RawData.ContainsKey("airship"));
         Assert.Null(model.Apn);
         Assert.False(model.RawData.ContainsKey("apn"));
+        Assert.Null(model.AwsSns);
+        Assert.False(model.RawData.ContainsKey("aws_sns"));
         Assert.Null(model.Birthdate);
         Assert.False(model.RawData.ContainsKey("birthdate"));
         Assert.Null(model.Custom);
@@ -493,8 +495,6 @@ public class UserProfileTest : TestBase
         Assert.False(model.RawData.ContainsKey("slack"));
         Assert.Null(model.Sub);
         Assert.False(model.RawData.ContainsKey("sub"));
-        Assert.Null(model.TargetArn);
-        Assert.False(model.RawData.ContainsKey("target_arn"));
         Assert.Null(model.UpdatedAt);
         Assert.False(model.RawData.ContainsKey("updated_at"));
         Assert.Null(model.Website);
@@ -519,6 +519,7 @@ public class UserProfileTest : TestBase
             Address = null,
             Airship = null,
             Apn = null,
+            AwsSns = null,
             Birthdate = null,
             Custom = null,
             Discord = null,
@@ -543,7 +544,6 @@ public class UserProfileTest : TestBase
             Profile = null,
             Slack = null,
             Sub = null,
-            TargetArn = null,
             UpdatedAt = null,
             Website = null,
             Zoneinfo = null,
@@ -555,6 +555,8 @@ public class UserProfileTest : TestBase
         Assert.True(model.RawData.ContainsKey("airship"));
         Assert.Null(model.Apn);
         Assert.True(model.RawData.ContainsKey("apn"));
+        Assert.Null(model.AwsSns);
+        Assert.True(model.RawData.ContainsKey("aws_sns"));
         Assert.Null(model.Birthdate);
         Assert.True(model.RawData.ContainsKey("birthdate"));
         Assert.Null(model.Custom);
@@ -603,8 +605,6 @@ public class UserProfileTest : TestBase
         Assert.True(model.RawData.ContainsKey("slack"));
         Assert.Null(model.Sub);
         Assert.True(model.RawData.ContainsKey("sub"));
-        Assert.Null(model.TargetArn);
-        Assert.True(model.RawData.ContainsKey("target_arn"));
         Assert.Null(model.UpdatedAt);
         Assert.True(model.RawData.ContainsKey("updated_at"));
         Assert.Null(model.Website);
@@ -621,6 +621,7 @@ public class UserProfileTest : TestBase
             Address = null,
             Airship = null,
             Apn = null,
+            AwsSns = null,
             Birthdate = null,
             Custom = null,
             Discord = null,
@@ -645,7 +646,6 @@ public class UserProfileTest : TestBase
             Profile = null,
             Slack = null,
             Sub = null,
-            TargetArn = null,
             UpdatedAt = null,
             Website = null,
             Zoneinfo = null,
@@ -670,6 +670,7 @@ public class UserProfileTest : TestBase
             },
             Airship = new() { Audience = new("named_user"), DeviceTypes = ["string"] },
             Apn = "apn",
+            AwsSns = new("target_arn"),
             Birthdate = "birthdate",
             Custom = new Dictionary<string, JsonElement>()
             {
@@ -702,7 +703,6 @@ public class UserProfileTest : TestBase
             Profile = "profile",
             Slack = new SendToSlackChannel() { AccessToken = "access_token", Channel = "channel" },
             Sub = "sub",
-            TargetArn = "target_arn",
             UpdatedAt = "updated_at",
             Website = "website",
             Zoneinfo = "zoneinfo",

--- a/src/TryCourier/Models/AwsSns.cs
+++ b/src/TryCourier/Models/AwsSns.cs
@@ -1,0 +1,77 @@
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using TryCourier.Core;
+
+namespace TryCourier.Models;
+
+/// <summary>
+/// Routes a push notification through the AWS SNS provider. The target ARN must be
+/// nested under `aws_sns` — a top-level `target_arn` on the profile is ignored by
+/// the provider.
+/// </summary>
+[JsonConverter(typeof(JsonModelConverter<AwsSns, AwsSnsFromRaw>))]
+public sealed record class AwsSns : JsonModel
+{
+    /// <summary>
+    /// The ARN of the SNS platform endpoint, topic, or application to publish to.
+    /// </summary>
+    public required string TargetArn
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNotNullClass<string>("target_arn");
+        }
+        init { this._rawData.Set("target_arn", value); }
+    }
+
+    /// <inheritdoc/>
+    public override void Validate()
+    {
+        _ = this.TargetArn;
+    }
+
+    public AwsSns() { }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    public AwsSns(AwsSns awsSns)
+        : base(awsSns) { }
+#pragma warning restore CS8618
+
+    public AwsSns(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+
+#pragma warning disable CS8618
+    [SetsRequiredMembers]
+    AwsSns(FrozenDictionary<string, JsonElement> rawData)
+    {
+        this._rawData = new(rawData);
+    }
+#pragma warning restore CS8618
+
+    /// <inheritdoc cref="AwsSnsFromRaw.FromRawUnchecked"/>
+    public static AwsSns FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData)
+    {
+        return new(FrozenDictionary.ToFrozenDictionary(rawData));
+    }
+
+    [SetsRequiredMembers]
+    public AwsSns(string targetArn)
+        : this()
+    {
+        this.TargetArn = targetArn;
+    }
+}
+
+class AwsSnsFromRaw : IFromRawJson<AwsSns>
+{
+    /// <inheritdoc/>
+    public AwsSns FromRawUnchecked(IReadOnlyDictionary<string, JsonElement> rawData) =>
+        AwsSns.FromRawUnchecked(rawData);
+}

--- a/src/TryCourier/Models/UserProfile.cs
+++ b/src/TryCourier/Models/UserProfile.cs
@@ -40,6 +40,21 @@ public sealed record class UserProfile : JsonModel
         init { this._rawData.Set("apn", value); }
     }
 
+    /// <summary>
+    /// Routes a push notification through the AWS SNS provider. The target ARN must
+    /// be nested under `aws_sns` — a top-level `target_arn` on the profile is ignored
+    /// by the provider.
+    /// </summary>
+    public AwsSns? AwsSns
+    {
+        get
+        {
+            this._rawData.Freeze();
+            return this._rawData.GetNullableClass<AwsSns>("aws_sns");
+        }
+        init { this._rawData.Set("aws_sns", value); }
+    }
+
     public string? Birthdate
     {
         get
@@ -290,16 +305,6 @@ public sealed record class UserProfile : JsonModel
         init { this._rawData.Set("sub", value); }
     }
 
-    public string? TargetArn
-    {
-        get
-        {
-            this._rawData.Freeze();
-            return this._rawData.GetNullableClass<string>("target_arn");
-        }
-        init { this._rawData.Set("target_arn", value); }
-    }
-
     public string? UpdatedAt
     {
         get
@@ -336,6 +341,7 @@ public sealed record class UserProfile : JsonModel
         this.Address?.Validate();
         this.Airship?.Validate();
         _ = this.Apn;
+        this.AwsSns?.Validate();
         _ = this.Birthdate;
         _ = this.Custom;
         this.Discord?.Validate();
@@ -360,7 +366,6 @@ public sealed record class UserProfile : JsonModel
         _ = this.Profile;
         this.Slack?.Validate();
         _ = this.Sub;
-        _ = this.TargetArn;
         _ = this.UpdatedAt;
         _ = this.Website;
         _ = this.Zoneinfo;

--- a/src/TryCourier/TryCourier.csproj
+++ b/src/TryCourier/TryCourier.csproj
@@ -9,12 +9,12 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="TryCourier.Tests"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <PackageReference Include="System.Text.Json" Version="9.0.9"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <InternalsVisibleTo Include="TryCourier.Tests" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0"/>
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

5 files changed, 174 insertions(+), 31 deletions(-)

<details><summary>Files</summary>

```
 src/TryCourier.Tests/Models/AwsSnsTest.cs      | 61 ++++++++++++++++++++++++++++++++++++
 src/TryCourier.Tests/Models/UserProfileTest.cs | 30 +++++++++---------
 src/TryCourier/Models/AwsSns.cs                | 77 ++++++++++++++++++++++++++++++++++++++++++++++
 src/TryCourier/Models/UserProfile.cs           | 27 +++++++++-------
 src/TryCourier/TryCourier.csproj               | 10 +++---
 5 files changed, 174 insertions(+), 31 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
